### PR TITLE
fix: eliminate duplicate snapshot entries in diary files

### DIFF
--- a/session_snapshot.py
+++ b/session_snapshot.py
@@ -209,37 +209,46 @@ def read_session_messages(session_path: Path, max_lines: int = 100) -> list:
         return []
 
 
+def build_message_lines(messages: list, agent_id: str) -> list[str]:
+    """将 messages 转成日记行列表（不含时间戳头部）"""
+    lines = []
+    for msg in messages:
+        role = msg.get('role', 'unknown')
+        content = msg.get('content', '')
+        label = "Boss" if role == "user" else agent_id.capitalize()
+        lines.append(f"- {label}: {content}")
+    return lines
+
+
 def write_to_memory(messages: list, path: Path, agent_id: str) -> int:
-    """写入 session 消息到 memory 文件"""
+    """写入 session 消息到 memory 文件，只写入尚未出现过的新消息行"""
     if not messages:
         return 0
 
     init_memory_file(path, agent_id)
 
-    time_marker = datetime.now().strftime("%H:%M")
-    new_content = f"\n### [{time_marker}] Session snapshot\n"
-
+    # 读取已有内容，用于去重
     try:
         existing = path.read_text(encoding='utf-8')
-        last_text = '\n'.join(existing.split('\n')[-20:])
     except:
-        last_text = ""
+        existing = ""
 
-    for msg in messages:
-        role = msg.get('role', 'unknown')
-        content = msg.get('content', '')
-        label = "Boss" if role == "user" else agent_id.capitalize()
-        new_content += f"- {label}: {content}\n"
+    # 过滤掉已经写过的行（不带时间戳，纯内容比较）
+    all_lines = build_message_lines(messages, agent_id)
+    new_lines = [line for line in all_lines if line not in existing]
 
-    if new_content in last_text:
-        logger.debug(f"[{agent_id}] No new messages to write")
+    if not new_lines:
+        logger.debug(f"[{agent_id}] All messages already recorded, skipping")
         return 0
+
+    time_marker = datetime.now().strftime("%H:%M")
+    block = f"\n### [{time_marker}] Session snapshot\n" + "\n".join(new_lines) + "\n"
 
     try:
         with open(path, 'a', encoding='utf-8') as f:
-            f.write(new_content)
-        logger.info(f"[{agent_id}] Wrote {len(messages)} messages to {path}")
-        return len(messages)
+            f.write(block)
+        logger.info(f"[{agent_id}] Wrote {len(new_lines)} new messages to {path}")
+        return len(new_lines)
     except Exception as e:
         logger.error(f"[{agent_id}] Failed to write: {e}")
         return 0


### PR DESCRIPTION
## Problem

`session_snapshot.py` was writing duplicate messages to diary files on every run. The previous deduplication logic was:

```python
if new_content in last_text:  # ❌ always fails — new_content has a fresh [HH:MM] timestamp
```

Since `new_content` was always prefixed with a new timestamp, the check never matched, causing the same messages to be appended repeatedly every 5–15 minutes. This resulted in diary files bloated with hundreds of identical entries.

## Root Cause

The dedup check compared a timestamp-prefixed block against the last 20 lines of the file. Because the timestamp changed on every run, the block never appeared identical, so dedup never triggered.

## Fix

- Extract message lines without the timestamp header
- Check each line individually against the **full diary file content**
- Only write lines that haven't appeared before
- Skip the entire write if all messages are already recorded

```python
# New approach
all_lines = build_message_lines(messages, agent_id)
new_lines = [line for line in all_lines if line not in existing]

if not new_lines:
    return 0  # nothing new, skip
```

## Effect

Each conversation message is written **at most once** per diary file, regardless of how many times the snapshot timer fires.