### PR TITLE
fix: align digest batch reads to section boundaries to avoid context cuts

### DIFF
--- a/pipelines/auto_digest.py
+++ b/pipelines/auto_digest.py
@@ -199,6 +199,7 @@ def process_agent(agent_id: str, workspace: Path, date: str, incremental: bool =
     incremental=False: 读取整个日记文件，LLM 提炼后写 mem0（昨日全量模式）
     incremental=True:  从 offset 开始分批读取（每批 50KB），逐批 POST 给 mem0，
                        批次间 sleep 避免打爆服务。处理完更新 offset，下次只读新增。
+    Batches are aligned to '## ' section boundaries to avoid cutting context mid-paragraph.
     """
     import time
 
@@ -235,12 +236,20 @@ def process_agent(agent_id: str, workspace: Path, date: str, incremental: bool =
                 if not raw:
                     break
 
-                batch_content = raw.decode('utf-8', errors='replace')
+                # Align to next section boundary "\n## " to avoid cutting context mid-paragraph
+                lookahead_raw = f.read(4096)
+                cut = lookahead_raw.find(b'\n## ')
+                if cut >= 0:
+                    raw = raw + lookahead_raw[:cut + 1]
+                else:
+                    raw = raw + lookahead_raw
+
+                batch_content = raw.decode("utf-8", errors="replace")
                 next_offset = current_offset + len(raw)
                 batch_num += 1
 
                 logger.info(f"[{agent_id}] Batch {batch_num}/{total_batches}: "
-                            f"offset {current_offset} -> {next_offset} ({len(raw)} bytes)")
+                            f"offset {current_offset} -> {next_offset} ({len(raw)} bytes, section-aligned)")
 
                 if batch_content.strip():
                     ok = write_to_mem0(batch_content, date, agent_id, incremental=True)


### PR DESCRIPTION
## 问题

增量模式（`auto_digest.py --today`）按固定字节（50KB）切分日记文件，会在句子中间硬截断，导致 mem0 提炼出的记忆上下文残缺，质量差。

## 修复

读取 50KB 后，额外读取 4096 字节 lookahead，在其中找到下一个 `\n## ` 段落标题作为截断点，确保每个 batch 都是完整的日记章节。

```python
# 对齐到下一个 ## 章节边界，避免上下文被截断
lookahead_raw = f.read(4096)
cut = lookahead_raw.find(b'\n## ')
if cut >= 0:
    raw = raw + lookahead_raw[:cut + 1]  # 到章节边界截断
else:
    raw = raw + lookahead_raw            # 靠近文件末尾，包含全部
```

日志也更新为 `section-aligned` 方便确认效果。

## 变更文件
- `pipelines/auto_digest.py`：仅修改批读取逻辑 + docstring + 日志（11行变更）