### PR TITLE
refactor: simplify pipeline - infer=True dedup, auto_dream via mem0 native add, add yesterday digest

### DIFF
--- a/docs/guide/how-it-works.md
+++ b/docs/guide/how-it-works.md
@@ -104,9 +104,10 @@ On every heartbeat tick, the agent performs memory maintenance in order:
                              │
                    ┌─────────┴──────────┐
                    ▼                    ▼
-             Promoted to           Deleted
-             long-term             (inactive)
-             memory
+             Step 1: digest        Step 2: consolidate
+             yesterday diary       7-day-old short-term
+             → long-term           → re-add long-term
+             (infer=True)          (infer=True) + delete
 ```
 
 ## Daily Automation Timeline
@@ -116,23 +117,23 @@ All automation runs as systemd user timers:
 | Time (UTC) | Script | What it does |
 |-----------|--------|--------------|
 | Every 5 min | `pipelines/session_snapshot.py` | Capture session conversations → diary file |
-| Every 15 min | `pipelines/auto_digest.py --today` | Incremental: read new diary content → write directly to mem0 short-term (today, no LLM) |
+| Every 15 min | `pipelines/auto_digest.py --today` | Incremental: read new diary content → mem0 short-term (infer=True, mem0 handles dedup) |
 | 01:00 | `pipelines/memory_sync.py` | Sync `MEMORY.md` → mem0 long-term (hash dedup) |
 | 01:30 | `pipelines/auto_digest.py` | Full mode: LLM-extract yesterday's complete diary → mem0 short-term |
-| 02:00 | `pipelines/auto_dream.py` | **AutoDream**: Evaluate 7-day-old short-term → promote or delete |
+| 02:00 | `pipelines/auto_dream.py` | **AutoDream**: Step 1: yesterday diary → mem0 long-term (infer=True); Step 2: 7-day-old short-term → re-add to long-term (infer=True) then delete |
 
 ## Two Modes of auto_digest
 
 `auto_digest.py` runs in two different modes:
 
 **`--today` mode (every 15 min, incremental)**
-Picks up new content from today's diary since the last run (offset-based). Writes directly to mem0 short-term memory without a local LLM call — mem0 handles fact extraction internally. Skips batches smaller than 500 bytes to avoid noisy micro-writes. On failure, retains the offset so the next run resumes from the same point.
+Picks up new content from today's diary since the last run (offset-based). Writes to mem0 short-term memory with `infer=True` — mem0 handles fact extraction and deduplication automatically. Skips batches smaller than 500 bytes to avoid noisy micro-writes. On failure, retains the offset so the next run resumes from the same point.
 
 **Default mode (UTC 01:30, full)**
 Reads yesterday's complete diary, calls a local Bedrock LLM (Claude Haiku) to extract meaningful short-term events, and writes each event individually to mem0. Higher quality output than incremental mode; acts as a cleanup pass to catch anything the 15-min incremental runs may have missed.
 
 ```
-Every 15 min (--today):  diary new content → direct POST to mem0 (no LLM)
+Every 15 min (--today):  diary new content → POST to mem0 (infer=True, mem0 dedup)
 UTC 01:30 (default):     yesterday's full diary → LLM extract → mem0
 ```
 
@@ -149,7 +150,7 @@ When a session's context window grows too large, OpenClaw compresses (compacts) 
 **Tertiary: Near-real-time cross-session memory sharing**
 Each agent may have multiple concurrent sessions — a direct chat session and one or more group chat sessions. Without a sharing mechanism, what an agent says in a group chat is invisible to its direct chat session (and vice versa).
 
-`session_snapshot.py` writes new conversation to the diary file every 5 minutes. `auto_digest.py --today` then picks up new diary content every 15 minutes and writes it directly to mem0 short-term memory (run_id=today, no local LLM). Any other session of the same agent can search mem0 and retrieve that content within ~20 minutes (5 min snapshot + 15 min digest) — no session restart required.
+`session_snapshot.py` writes new conversation to the diary file every 5 minutes. `auto_digest.py --today` then picks up new diary content every 15 minutes and writes it to mem0 short-term memory with `infer=True` (run_id=today, mem0 handles dedup). Any other session of the same agent can search mem0 and retrieve that content within ~20 minutes (5 min snapshot + 15 min digest) — no session restart required.
 
 Session keys are tagged in metadata (`session_key`), so you can filter by source if needed.
 
@@ -219,7 +220,7 @@ If the new session starts before 01:30, mem0 doesn't have last night's content y
 | Yesterday after-midnight to 01:30 | `memory/yesterday.md` (gap buffer) |
 | Yesterday 01:30 onward | mem0 short-term (distilled) |
 | Last 7 days | mem0 short-term (`--combined`) |
-| Older than 7 days | mem0 long-term (AutoDream-promoted) |
+| Older than 7 days | mem0 long-term (AutoDream-consolidated) |
 
 All three sources together — today's diary + yesterday's diary + mem0 — create **zero blind spots** across all session reset scenarios.
 

--- a/docs/zh/guide/how-it-works.md
+++ b/docs/zh/guide/how-it-works.md
@@ -104,8 +104,10 @@ Agent 读到「🔴 Agent Memory Behavior」规则
                              │
                    ┌─────────┴──────────┐
                    ▼                    ▼
-             升级为长期记忆          删除
-             （活跃话题）           （不活跃）
+             Step 1: 消化            Step 2: 整合
+             昨日日记               7天前短期记忆
+             → 长期记忆             → re-add 长期
+             (infer=True)          (infer=True) + 删除
 ```
 
 ## 每日自动化时序
@@ -115,23 +117,23 @@ Agent 读到「🔴 Agent Memory Behavior」规则
 | 时间（UTC） | 脚本 | 做什么 |
 |------------|------|--------|
 | 每 5 分钟 | `pipelines/session_snapshot.py` | 捕获会话对话 → 日记文件 |
-| 每 15 分钟 | `pipelines/auto_digest.py --today` | 增量模式：读取日记新增内容 → 直接写入 mem0 短期记忆（今日，无 LLM） |
+| 每 15 分钟 | `pipelines/auto_digest.py --today` | 增量模式：读取日记新增内容 → mem0 短期记忆（infer=True，mem0 自动去重） |
 | 01:00 | `pipelines/memory_sync.py` | 同步 `MEMORY.md` → mem0 长期记忆（hash 去重） |
 | 01:30 | `pipelines/auto_digest.py` | 全量模式：LLM 提取昨日完整日记 → mem0 短期记忆 |
-| 02:00 | `pipelines/auto_dream.py` | **AutoDream**：评估 7 天前短期记忆 → 升级或删除 |
+| 02:00 | `pipelines/auto_dream.py` | **AutoDream**：Step1: 昨日日记 → mem0 长期记忆（infer=True）；Step2: 7天前短期记忆 → re-add 到长期（infer=True）后删除 |
 
 ## auto_digest 的两种模式
 
 `auto_digest.py` 以两种不同模式运行：
 
 **`--today` 增量模式（每 15 分钟）**
-基于 offset 记录，每次只读取日记文件自上次运行以来的新增内容。不调用本地 LLM，直接 POST 给 mem0（由 mem0 内部做 fact extraction）。新增内容不足 500 字节时跳过，避免无意义的小写入。写入失败时保留 offset，下次从同一断点续传。
+基于 offset 记录，每次只读取日记文件自上次运行以来的新增内容。以 `infer=True` 写入 mem0，由 mem0 自动做 fact extraction 和去重。新增内容不足 500 字节时跳过，避免无意义的小写入。写入失败时保留 offset，下次从同一断点续传。
 
 **默认全量模式（UTC 01:30）**
 读取昨天的完整日记文件，调用本地 Bedrock LLM（Claude Haiku）提取有意义的短期事件，逐条写入 mem0。输出质量高于增量模式，同时作为兜底——补齐 15 分钟增量模式可能遗漏的内容。
 
 ```
-每 15 分钟 (--today)：  日记新增内容 → 直接 POST 给 mem0（无 LLM）
+每 15 分钟 (--today)：  日记新增内容 → POST 给 mem0（infer=True，mem0 去重）
 UTC 01:30 (默认)：      昨日完整日记 → LLM 提取 → mem0
 ```
 
@@ -148,7 +150,7 @@ Agent 每天重置。没有 snapshot，session 之间的对话就会丢失。Sna
 **第三个角色：近实时跨 session 记忆共享**
 同一个 agent 可能有多个并发 session——一个单聊 session 和一个或多个群聊 session。没有共享机制的话，agent 在群聊里说的内容，单聊 session 完全看不到（反之亦然）。
 
-`session_snapshot.py` 每 5 分钟将新对话写入日记文件，`auto_digest.py --today` 再每 15 分钟增量读取日记新增内容，直接写入 mem0 短期记忆（run_id=今天，不经过本地 LLM）。同一 agent 的其他 session 搜索 mem0 即可在约 **20 分钟内**（5 分钟 snapshot + 15 分钟 digest）获取到这些内容——无需重启 session。
+`session_snapshot.py` 每 5 分钟将新对话写入日记文件，`auto_digest.py --today` 再每 15 分钟增量读取日记新增内容，以 `infer=True` 写入 mem0 短期记忆（run_id=今天，mem0 自动去重）。同一 agent 的其他 session 搜索 mem0 即可在约 **20 分钟内**（5 分钟 snapshot + 15 分钟 digest）获取到这些内容——无需重启 session。
 
 session 来源记录在 metadata 的 `session_key` 字段中，需要时可按来源过滤。
 
@@ -218,7 +220,7 @@ Session 启动
 | 昨天深夜到今天 01:30 | `memory/昨天.md`（盲区缓冲） |
 | 昨天 01:30 之后 | mem0 短期记忆（已提炼） |
 | 最近 7 天 | mem0 短期记忆（`--combined`） |
-| 7 天以上 | mem0 长期记忆（AutoDream 升级后） |
+| 7 天以上 | mem0 长期记忆（AutoDream 整合后） |
 
 三个来源组合——今天日记 + 昨天日记 + mem0——在所有 session 重置场景下实现**零盲区**覆盖。
 

--- a/pipelines/auto_digest.py
+++ b/pipelines/auto_digest.py
@@ -172,14 +172,13 @@ def write_to_mem0(event: str, run_id: str, agent_id: str, incremental: bool = Fa
             "digest_date": run_id,
             "workspace_agent": agent_id
         }
-        if incremental:
-            metadata["mode"] = "direct"  # 直接写，不经过本地 LLM
 
         resp = requests.post(MEM0_API_URL, json={
             "user_id": "boss",
             "agent_id": agent_id,
             "run_id": run_id,
             "text": event,
+            "infer": True,
             "metadata": metadata
         }, timeout=30)
         resp.raise_for_status()

--- a/pipelines/auto_dream.py
+++ b/pipelines/auto_dream.py
@@ -2,14 +2,10 @@
 """
 auto_dream.py - AutoDream 记忆沉淀（夜间自动巩固）
 
-每天运行一次，处理所有 agent 7天前的短期记忆：
-1. 从 openclaw.json 发现所有 agent（与 session_snapshot / auto_digest 保持一致）
-2. 找到7天前（run_id=7天前日期）的所有短期记忆
-3. 对每条记忆，用其内容在近7天短期记忆中做语义搜索
-4. 如果有相关讨论（score > 0.75）→ 升级为长期记忆（无 run_id 写入）
-5. 如果没有相关讨论 → 直接删除
-
-Inspired by how human brains consolidate short-term into long-term memories during sleep.
+每天 UTC 02:00 运行，对每个 agent 执行两步：
+  Step 1: 读取昨日日记 → POST mem0.add(infer=True, 无 run_id) → 长期记忆
+  Step 2: 找到 7 天前的短期记忆 → 逐条 re-add 到 mem0(infer=True, 无 run_id) → 删除原始短期条目
+         mem0 原生决定 ADD/UPDATE/DELETE/NONE，不再手写语义搜索判断。
 """
 
 import json
@@ -25,14 +21,12 @@ from pathlib import Path
 
 BASE_URL = "http://127.0.0.1:8230"
 USER_ID = "boss"
-ARCHIVE_DAYS = 7        # 处理多少天前的短期记忆
-ACTIVE_THRESHOLD = 0.75  # 活跃度判断阈值（语义相似度）
-MAX_MEMORIES_PER_RUN = 300  # 单次运行每个 agent 最多处理的记忆数（分页模式，剩余留到下次）
-MAX_CONSECUTIVE_ERRORS = 3  # 连续错误达到此数则跳过该 agent 剩余记忆
-INTER_MEMORY_SLEEP = 1.0    # 每条记忆处理后的 sleep（秒），防止打爆 server
+ARCHIVE_DAYS = 7
+MAX_MEMORIES_PER_RUN = 300
+MAX_CONSECUTIVE_ERRORS = 3
+INTER_MEMORY_SLEEP = 1.0
 LOG_FILE = Path(__file__).parent.parent / "auto_dream.log"
 
-# 优先读环境变量 OPENCLAW_HOME，其次 ~/.openclaw
 OPENCLAW_BASE = Path(os.environ.get("OPENCLAW_HOME", Path.home() / ".openclaw"))
 OPENCLAW_CONFIG = OPENCLAW_BASE / "openclaw.json"
 
@@ -71,19 +65,53 @@ def load_agent_ids() -> list[str]:
                         _extract(v)
 
             _extract(config)
-            logger.debug(f"Loaded {len(agent_ids)} agents from openclaw.json: {agent_ids}")
             return agent_ids
         except Exception as e:
             logger.warning(f"Failed to parse openclaw.json: {e}, falling back to directory scan")
 
-    # 兜底：扫描 workspace-* 目录
     for ws_dir in sorted(OPENCLAW_BASE.glob("workspace-*")):
         agent_ids.append(ws_dir.name.replace("workspace-", ""))
-    logger.debug(f"Fallback scan found agents: {agent_ids}")
     return agent_ids
 
 
-# ─── Core Functions ───
+def load_agent_workspaces() -> dict[str, Path]:
+    """从 openclaw.json 读取 agent_id → workspace Path 映射"""
+    mapping = {}
+
+    if OPENCLAW_CONFIG.exists():
+        try:
+            with open(OPENCLAW_CONFIG) as f:
+                config = json.load(f)
+
+            def _extract(obj):
+                if isinstance(obj, dict):
+                    if 'id' in obj and 'workspace' in obj and isinstance(obj.get('workspace'), str):
+                        mapping[obj['id']] = Path(obj['workspace'])
+                    for v in obj.values():
+                        _extract(v)
+                elif isinstance(obj, list):
+                    for v in obj:
+                        _extract(v)
+
+            _extract(config)
+        except Exception as e:
+            logger.warning(f"Failed to parse openclaw.json: {e}, falling back to directory scan")
+
+    if not mapping:
+        for ws_dir in sorted(OPENCLAW_BASE.glob("workspace-*")):
+            agent_id = ws_dir.name.replace("workspace-", "")
+            mapping[agent_id] = ws_dir
+
+    return mapping
+
+
+# ─── Helpers ───
+
+def get_beijing_yesterday() -> str:
+    tz_beijing = timezone(timedelta(hours=8))
+    yesterday = datetime.now(tz_beijing).date() - timedelta(days=1)
+    return yesterday.strftime("%Y-%m-%d")
+
 
 def get_short_term_memories(agent_id: str, run_id: str) -> list:
     """获取指定 agent + run_id 的所有短期记忆"""
@@ -101,62 +129,6 @@ def get_short_term_memories(agent_id: str, run_id: str) -> list:
         return []
 
 
-def is_topic_active(agent_id: str, memory_text: str, exclude_run_id: str) -> bool:
-    """判断话题是否在近7天还活跃（语义搜索近期短期记忆）"""
-    tz_beijing = timezone(timedelta(hours=8))
-    today = datetime.now(tz_beijing).date()
-
-    for i in range(1, ARCHIVE_DAYS):
-        day = today - timedelta(days=i)
-        run_id = day.strftime("%Y-%m-%d")
-        if run_id == exclude_run_id:
-            continue
-
-        payload = {
-            "query": memory_text,
-            "user_id": USER_ID,
-            "agent_id": agent_id,
-            "run_id": run_id,
-            "top_k": 3
-        }
-        try:
-            resp = requests.post(f"{BASE_URL}/memory/search", json=payload, timeout=30)
-            resp.raise_for_status()
-            results = resp.json().get("results", [])
-            if isinstance(results, dict):
-                results = results.get("results", [])
-            for r in results:
-                if r.get("score", 0) >= ACTIVE_THRESHOLD:
-                    logger.debug(f"  [{agent_id}] Active match (score={r['score']:.2f}) in run_id={run_id}")
-                    return True
-        except Exception as e:
-            logger.debug(f"  [{agent_id}] Error searching run_id={run_id}: {e}")
-
-    return False
-
-
-def promote_to_long_term(agent_id: str, memory_text: str, original_metadata: dict):
-    """升级为长期记忆（不带 run_id）"""
-    metadata = {k: v for k, v in (original_metadata or {}).items()
-                if k not in ("category", "source", "digest_date")}
-    metadata["category"] = "experience"
-    metadata["source"] = "autodream_promoted"
-
-    payload = {
-        "user_id": USER_ID,
-        "agent_id": agent_id,
-        "text": memory_text,
-        "metadata": metadata
-    }
-    try:
-        resp = requests.post(f"{BASE_URL}/memory/add", json=payload, timeout=60)
-        resp.raise_for_status()
-        logger.info(f"  [{agent_id}] ✓ Promoted to long-term memory")
-    except Exception as e:
-        logger.error(f"  [{agent_id}] ✗ Failed to promote: {e}")
-        raise
-
-
 def delete_memory(memory_id: str):
     """删除记忆"""
     try:
@@ -167,59 +139,75 @@ def delete_memory(memory_id: str):
         raise
 
 
-def archive_agent(agent_id: str, target_run_id: str) -> tuple[int, int]:
-    """处理单个 agent 的短期记忆归档，返回 (promoted, deleted)"""
+# ─── Step 1: Digest Yesterday Diary ───
+
+def digest_yesterday(agent_id: str, workspace: Path):
+    """读取昨日日记 → POST mem0.add(infer=True, 无 run_id) → 长期记忆"""
+    yesterday = get_beijing_yesterday()
+    diary_file = workspace / "memory" / f"{yesterday}.md"
+    if not diary_file.exists():
+        logger.info(f"[{agent_id}] No diary for {yesterday}, skipping digest")
+        return
+    content = diary_file.read_text(encoding="utf-8").strip()
+    if not content:
+        logger.info(f"[{agent_id}] Empty diary for {yesterday}, skipping digest")
+        return
+    resp = requests.post(f"{BASE_URL}/memory/add", json={
+        "user_id": USER_ID,
+        "agent_id": agent_id,
+        "text": content,
+        "infer": True,
+        "metadata": {"source": "auto_dream_digest", "digest_date": yesterday}
+    }, timeout=120)
+    resp.raise_for_status()
+    logger.info(f"[{agent_id}] Digested yesterday diary ({len(content)} chars) into long-term memory")
+
+
+# ─── Step 2: Consolidate Old Short-Term Memories ───
+
+def consolidate_old_memories(agent_id: str, target_run_id: str) -> int:
+    """逐条 re-add 7天前短期记忆到长期(infer=True, 无 run_id)，然后删除原始条目"""
     memories = get_short_term_memories(agent_id, target_run_id)
     if not memories:
-        logger.info(f"[{agent_id}] No short-term memories for {target_run_id}, skipping")
-        return 0, 0
+        logger.info(f"[{agent_id}] No short-term memories for {target_run_id}")
+        return 0
 
-    logger.info(f"[{agent_id}] Found {len(memories)} memories to process")
-
-    if len(memories) > MAX_MEMORIES_PER_RUN:
-        logger.warning(
-            f"[{agent_id}] Too many memories ({len(memories)}), "
-            f"processing first {MAX_MEMORIES_PER_RUN} this run (remainder will be processed in future runs)"
-        )
-        memories = memories[:MAX_MEMORIES_PER_RUN]
-
-    promoted = 0
-    deleted = 0
+    processed = 0
     consecutive_errors = 0
+    cap = min(len(memories), MAX_MEMORIES_PER_RUN)
+    if len(memories) > MAX_MEMORIES_PER_RUN:
+        logger.warning(f"[{agent_id}] {len(memories)} memories, processing first {cap} (paging)")
 
-    for mem in memories:
+    for mem in memories[:cap]:
         mem_id = mem.get("id")
         mem_text = mem.get("memory", "")
-        mem_metadata = mem.get("metadata", {})
-
-        if not mem_text or not mem_id:
-            logger.warning(f"[{agent_id}] Skipping memory with missing id or text: {mem}")
+        if not mem_id or not mem_text:
             continue
-
-        logger.info(f"[{agent_id}] Processing: {mem_text[:60]}...")
-
         try:
-            if is_topic_active(agent_id, mem_text, target_run_id):
-                logger.info(f"[{agent_id}]   → Active topic, promoting to long-term")
-                promote_to_long_term(agent_id, mem_text, mem_metadata)
-                delete_memory(mem_id)
-                promoted += 1
-            else:
-                logger.info(f"[{agent_id}]   → Inactive topic, deleting")
-                delete_memory(mem_id)
-                deleted += 1
+            resp = requests.post(f"{BASE_URL}/memory/add", json={
+                "user_id": USER_ID,
+                "agent_id": agent_id,
+                "text": mem_text,
+                "infer": True,
+                "metadata": {"source": "auto_dream_consolidated", "original_run_id": target_run_id}
+            }, timeout=120)
+            resp.raise_for_status()
+            delete_memory(mem_id)
+            processed += 1
             consecutive_errors = 0
+            logger.info(f"[{agent_id}] Consolidated: {mem_text[:60]}...")
         except Exception as e:
             consecutive_errors += 1
-            logger.error(f"[{agent_id}]   → Error ({consecutive_errors}/{MAX_CONSECUTIVE_ERRORS}): {e}")
+            logger.error(f"[{agent_id}] Error ({consecutive_errors}/{MAX_CONSECUTIVE_ERRORS}): {e}")
             if consecutive_errors >= MAX_CONSECUTIVE_ERRORS:
-                logger.error(f"[{agent_id}] {MAX_CONSECUTIVE_ERRORS} consecutive errors, aborting remaining memories")
+                logger.error(f"[{agent_id}] Aborting after {MAX_CONSECUTIVE_ERRORS} consecutive errors")
                 break
-
         time.sleep(INTER_MEMORY_SLEEP)
 
-    return promoted, deleted
+    return processed
 
+
+# ─── Main ───
 
 def main():
     logger.info("=" * 80)
@@ -231,26 +219,23 @@ def main():
     target_run_id = target_date.strftime("%Y-%m-%d")
 
     logger.info(f"Beijing date: {today}")
-    logger.info(f"Archiving short-term memories for run_id={target_run_id}")
+    logger.info(f"Target run_id for consolidation: {target_run_id}")
 
-    agent_ids = load_agent_ids()
-    logger.info(f"Discovered {len(agent_ids)} agents: {agent_ids}")
+    workspaces = load_agent_workspaces()
+    logger.info(f"Discovered {len(workspaces)} agents: {list(workspaces.keys())}")
 
-    total_promoted = 0
-    total_deleted = 0
+    total_consolidated = 0
 
-    for agent_id in agent_ids:
+    for agent_id, workspace in sorted(workspaces.items()):
         try:
-            promoted, deleted = archive_agent(agent_id, target_run_id)
-            total_promoted += promoted
-            total_deleted += deleted
+            # Step 1: digest yesterday diary → long-term memory
+            digest_yesterday(agent_id, workspace)
+            # Step 2: consolidate 7-day-old short-term → long-term, then delete
+            total_consolidated += consolidate_old_memories(agent_id, target_run_id)
         except Exception as e:
             logger.error(f"[{agent_id}] Fatal error: {e}", exc_info=True)
 
-    logger.info(f"\nAutoDream complete (all agents):")
-    logger.info(f"  - Promoted to long-term: {total_promoted}")
-    logger.info(f"  - Deleted as inactive:   {total_deleted}")
-    logger.info(f"  - Total processed:       {total_promoted + total_deleted}")
+    logger.info(f"\nAutoDream complete: consolidated {total_consolidated} memories")
     logger.info("=" * 80)
 
 

--- a/server.py
+++ b/server.py
@@ -147,6 +147,7 @@ class AddMemoryRequest(BaseModel):
     agent_id: Optional[str] = Field(None, description="Agent identifier (e.g. 'dev', 'main')")
     run_id: Optional[str] = Field(None, description="Run/session identifier (e.g. YYYY-MM-DD for short-term memories)")
     metadata: Optional[Dict[str, Any]] = Field(None, description="Extra metadata tags")
+    infer: bool = Field(True, description="Whether mem0 should infer/extract facts (True) or store raw text (False)")
 
 
 class SearchMemoryRequest(BaseModel):
@@ -208,13 +209,14 @@ async def add_memory(req: AddMemoryRequest):
     async with _add_semaphore:
         try:
             loop = asyncio.get_event_loop()
+            infer = req.infer  # capture for lambda to avoid late binding
             if req.messages:
                 result = await loop.run_in_executor(
-                    _mem0_executor, lambda: memory.add(req.messages, **kwargs)
+                    _mem0_executor, lambda: memory.add(req.messages, infer=infer, **kwargs)
                 )
             else:
                 result = await loop.run_in_executor(
-                    _mem0_executor, lambda: memory.add(req.text, **kwargs)
+                    _mem0_executor, lambda: memory.add(req.text, infer=infer, **kwargs)
                 )
             return {"status": "ok", "result": result}
         except Exception as e:


### PR DESCRIPTION
## 重构 mem0 pipeline

### 背景
经过深入讨论，发现原有架构有三个问题：
1. `auto_digest --today` 用 `infer=False` 写入，mem0 不做去重 → 积累大量重复短期记忆（今天 blog 952 条、main 2015 条的根因之一）
2. `auto_dream` 手写 `is_topic_active()` 语义比对 → 952 条 × 6次 API = 5712次 Bedrock 调用，重新实现了 mem0 原生能力
3. 昨日日记 LLM 精华提炼从来没有真正跑过（service 路径错误）

### 修改内容

**server.py**
- `AddMemoryRequest` 新增 `infer: bool = Field(True)` 参数，传给 `memory.add()`

**pipelines/auto_digest.py**
- `write_to_mem0()` 加入 `"infer": True`，由 mem0 自动做 fact extraction + 去重
- 去掉 `"mode": "direct"` metadata tag

**pipelines/auto_dream.py（大幅简化）**
- 删除：`is_topic_active()`、`promote_to_long_term()`、`archive_agent()`
- 新增 Step1 `digest_yesterday()`：读昨日日记 → `mem0.add(infer=True, 无run_id)` → 长期记忆
- 新增 Step2 `consolidate_old_memories()`：7天前短期记忆逐条 re-add（infer=True, 无run_id）→ 删除原始条目，由 mem0 原生决策 ADD/UPDATE/DELETE/NONE
- 净减少代码：133 insertions, 144 deletions

**docs/guide/how-it-works.md + docs/zh/guide/how-it-works.md**
- 更新每日时序表、流程图、auto_dream 章节描述