### PR TITLE
docs: update architecture.md to reflect new auto_dream two-step logic (PR #25)

### DIFF
--- a/docs/guide/architecture.md
+++ b/docs/guide/architecture.md
@@ -14,7 +14,7 @@ flowchart TD
     Diary["memory/YYYY-MM-DD.md\n(diary files)"]
     MemoryMD["MEMORY.md\n(agent curated knowledge)"]
     Snap(["session_snapshot.py\n(every 5 min, diary only)"])
-    DigestToday(["auto_digest.py --today\n(every 15 min, incremental batches)"])
+    DigestToday(["auto_digest.py --today\n(every 15 min, infer=True, mem0 dedup)"])
     DigestFull(["auto_digest.py\n(daily UTC 01:30, yesterday full)"])
     Sync(["memory_sync.py\n(daily, MEMORY.md)"])
     Archive(["auto_dream.py\n(AutoDream)"])
@@ -26,7 +26,6 @@ flowchart TD
         LTM["Long-term Memory\n(no run_id)"]
     end
 
-    Decision{"Active?"}
 
     subgraph Store["Vector Store"]
         S3[("S3 Vectors")]
@@ -46,10 +45,9 @@ flowchart TD
     DigestToday --> STM
     DigestFull --> STM
     Sync --> LTM
-    STM -- "daily UTC 02:00" --> Archive
-    Archive --> Decision
-    Decision -- "active" --> LTM
-    Decision -- "inactive" --> Del["🗑 Delete"]
+    STM -- "daily UTC 02:00\n(7-day-old entries)" --> Archive
+    Archive -- "Step 1: yesterday diary\n(infer=True)" --> LTM
+    Archive -- "Step 2: re-add + delete\n(infer=True, mem0 decides)" --> LTM
 
     STM --> LLM
     STM --> Embed
@@ -67,10 +65,10 @@ flowchart TD
 | Component | Role |
 |---|---|
 | **session_snapshot.py** | Runs every 5 minutes. Captures **all** agent sessions (direct chat + group chats) into daily diary files. **Does not write to mem0 directly** — mem0 ingestion is handled entirely by auto_digest. |
-| **auto_digest.py --today** | Runs every 15 minutes. Reads only the **new bytes** added since the last run (tracked via `auto_digest_offset.json`). Sends content to mem0 in **section-aligned batches** (up to ~50KB each, aligned to `## ` diary section boundaries) — this avoids cutting context mid-paragraph. Offset is persisted after each successful batch, enabling crash-safe resume. |
+| **auto_digest.py --today** | Runs every 15 minutes. Reads only the **new bytes** added since the last run (tracked via `auto_digest_offset.json`). Sends content to mem0 in **section-aligned batches** (up to ~50KB each, aligned to `## ` diary section boundaries) with `infer=True` — mem0 handles fact extraction and deduplication automatically. Offset is persisted after each successful batch, enabling crash-safe resume. |
 | **auto_digest.py** (daily) | Runs daily at UTC 01:30. Processes **yesterday's complete diary** in one pass using LLM distillation — higher quality extraction with full-day context. Writes to mem0 as short-term memories (`run_id=date`). |
 | **memory_sync.py** | Runs daily at UTC 01:00. Syncs each agent's `MEMORY.md` (curated knowledge) directly to mem0 long-term memory. Hash-based dedup skips unchanged files — zero LLM cost if nothing changed. |
-| **auto_dream.py** / **AutoDream** | Runs daily at UTC 02:00. Promotes active short-term memories to long-term (removes `run_id`); deletes inactive ones. |
+| **auto_dream.py** / **AutoDream** | Runs daily at UTC 02:00. **Step 1**: digests yesterday's diary into long-term memory (infer=True, no run_id). **Step 2**: for each 7-day-old short-term memory, re-adds it to mem0 with infer=True (no run_id) — mem0 natively decides ADD/UPDATE/DELETE/NONE — then deletes the original short-term entry. |
 | **mem0 Memory Service** | Core service. Uses AWS Bedrock LLM for memory distillation/deduplication and Bedrock Embedding for vectorization. |
 | **Vector Store** | Persists memory vectors. Supports S3 Vectors or OpenSearch as the backend. |
 | **SKILL.md → Retrieval** | On new agent sessions, reads SKILL.md, queries mem0 for relevant memories, and injects them as context. |
@@ -82,7 +80,7 @@ Every 5 min   session_snapshot  — conversations → diary files  (no mem0 writ
 Every 15 min  auto_digest --today — diary new bytes → mem0 short-term  (real-time, batched)
 01:00         memory_sync       — MEMORY.md → mem0 long-term  (curated knowledge, instant)
 01:30         auto_digest       — yesterday's diary → mem0 short-term  (full-day LLM distill)
-02:00         auto_dream (AutoDream)           — 7-day-old short-term → promote or delete
+02:00         auto_dream (AutoDream)           — Step1: yesterday diary → long-term (infer=True); Step2: 7-day-old short-term → re-add (infer=True) + delete
 ```
 
 ## Memory Tiering: Who Decides Long vs. Short-Term?
@@ -92,7 +90,7 @@ mem0 itself has no concept of short-term or long-term — it stores everything p
 | | Short-term | Long-term |
 |---|---|---|
 | **`run_id`** | `YYYY-MM-DD` (date string) | absent |
-| **Written by** | `auto_digest.py` (automated) | Agent explicitly, `memory_sync.py`, or `auto_dream.py` / AutoDream (promoted) |
+| **Written by** | `auto_digest.py` (automated) | Agent explicitly, `memory_sync.py`, or `auto_dream.py` / AutoDream (consolidated via infer=True) |
 | **Lifetime** | 7 days → evaluated for promotion | Permanent |
 | **Typical content** | Daily discussions, task progress, temp decisions | Tech decisions, lessons learned, user preferences |
 
@@ -106,12 +104,11 @@ This is the **fastest path**: important decisions and lessons reach long-term me
 
 **Path 2 — `auto_dream.py` / AutoDream** (daily, automatic promotion from short-term)
 
-After 7 days, each short-term memory is evaluated:
-- Semantically search the past 6 days of short-term memories
-- If a similar topic is found with score ≥ 0.75 → **promoted** (re-written without `run_id`)
-- Otherwise → **deleted**
+After 7 days, each short-term memory is re-added to mem0 with `infer=True` (without `run_id`). mem0 natively decides whether to ADD (new knowledge), UPDATE (merge with existing), DELETE (redundant), or NONE (no action needed). The original short-term entry is then deleted.
 
-This handles topics that were discussed over multiple days but never explicitly captured in `MEMORY.md`.
+Also runs Step 1 at the start: digests yesterday's diary directly into long-term memory (infer=True, no run_id) for high-quality nightly knowledge extraction.
+
+This replaces the previous hand-written semantic search (is_topic_active), eliminating thousands of redundant Bedrock API calls and leveraging mem0's native intelligence instead.
 
 **Path 3 — Agent explicit write** (on-demand)
 
@@ -149,6 +146,8 @@ This provides **real-time memory**: conversations from the last 15 minutes are a
 Runs once per day on yesterday's complete diary. With the full day's context available, the LLM produces higher-quality, deduplicated memories that capture the day's overall arc rather than isolated fragments.
 
 This provides **high-quality retrospective memory** without the cost of running LLM on every incremental batch.
+
+Note: Since PR #25, auto_dream also handles yesterday diary digestion (Step 1) — the previous standalone `auto_digest.py` daily mode at UTC 01:30 has been superseded.
 
 ### Why session_snapshot no longer writes to mem0
 

--- a/docs/zh/guide/architecture.md
+++ b/docs/zh/guide/architecture.md
@@ -14,7 +14,7 @@ flowchart TD
     Diary["memory/YYYY-MM-DD.md\n（日记文件）"]
     MemoryMD["MEMORY.md\n（Agent 精选知识库）"]
     Snap(["session_snapshot.py\n（每 5 分钟，仅写日记）"])
-    DigestToday(["auto_digest.py --today\n（每 15 分钟，增量分批写入）"])
+    DigestToday(["auto_digest.py --today\n（每 15 分钟，infer=True，mem0 去重）"])
     DigestFull(["auto_digest.py\n（每天 UTC 01:30，昨日全量）"])
     Sync(["memory_sync.py\n（每天，同步 MEMORY.md）"])
     Archive(["auto_dream.py\n(AutoDream)"])
@@ -26,7 +26,6 @@ flowchart TD
         LTM["长期记忆\n（无 run_id）"]
     end
 
-    Decision{"活跃？"}
 
     subgraph Store["向量存储"]
         S3[("S3 Vectors")]
@@ -46,10 +45,9 @@ flowchart TD
     DigestToday --> STM
     DigestFull --> STM
     Sync --> LTM
-    STM -- "每天 UTC 02:00" --> Archive
-    Archive --> Decision
-    Decision -- "活跃" --> LTM
-    Decision -- "不活跃" --> Del["🗑 删除"]
+    STM -- "每天 UTC 02:00\n（7天前条目）" --> Archive
+    Archive -- "步骤一：昨日日记\n（infer=True）" --> LTM
+    Archive -- "步骤二：重新写入 + 删除\n（infer=True，mem0 决策）" --> LTM
 
     STM --> LLM
     STM --> Embed
@@ -67,10 +65,10 @@ flowchart TD
 | 组件 | 职责 |
 |---|---|
 | **session_snapshot.py** | 每 5 分钟运行一次。捕获**所有** Agent 会话（单聊 + 群聊）到日记文件。**不再直接写入 mem0**——mem0 的写入完全由 auto_digest 负责。 |
-| **auto_digest.py --today** | 每 15 分钟运行一次。读取自上次运行以来日记文件中的**新增字节**（通过 `auto_digest_offset.json` 追踪），以**按 `## ` 章节边界对齐的分批**方式（每批最大约 50KB）发送给 mem0（由 mem0 内部做 fact extraction），避免在段落中间截断上下文。每批成功后立即持久化 offset，支持断点续传。 |
+| **auto_digest.py --today** | 每 15 分钟运行一次。读取自上次运行以来日记文件中的**新增字节**（通过 `auto_digest_offset.json` 追踪），以**按 `## ` 章节边界对齐的分批**方式（每批最大约 50KB）发送给 mem0，使用 `infer=True`——mem0 自动处理事实提取和去重。每批成功后立即持久化 offset，支持断点续传。 |
 | **auto_digest.py**（每日） | 每天 UTC 01:30 运行。通过 LLM 提炼**昨天的完整日记**，一次性处理——利用全天完整上下文产出更高质量的记忆。写入 mem0 短期记忆（`run_id=日期`）。 |
 | **memory_sync.py** | 每天 UTC 01:00 运行。将各 Agent 的 `MEMORY.md`（精选知识）直接同步到 mem0 长期记忆。基于内容 hash 去重，文件未变化时零 LLM 调用。 |
-| **auto_dream.py** / **AutoDream** | 每天 UTC 02:00 运行，将活跃的短期记忆升级为长期记忆（移除 `run_id`），删除不活跃的记忆。 |
+| **auto_dream.py** / **AutoDream** | 每天 UTC 02:00 运行。**步骤一**：将昨日日记消化为长期记忆（infer=True，无 run_id）。**步骤二**：对每条 7 天前的短期记忆，以 infer=True（无 run_id）重新写入 mem0——mem0 原生决策 ADD/UPDATE/DELETE/NONE——然后删除原始短期条目。 |
 | **mem0 Memory Service** | 核心服务。使用 AWS Bedrock LLM 进行记忆提炼与去重，使用 Bedrock Embedding 进行向量化。 |
 | **向量存储** | 持久化记忆向量，支持 S3 Vectors 或 OpenSearch 作为后端。 |
 | **SKILL.md → 检索** | Agent 新会话启动时，读取 SKILL.md，查询 mem0 获取相关记忆，注入为上下文。 |
@@ -82,7 +80,7 @@ flowchart TD
 每 15 分钟   auto_digest --today — 日记新增内容 → mem0 短期记忆（实时，分批写入）
 01:00        memory_sync        — MEMORY.md → mem0 长期记忆（精选知识，即时生效）
 01:30        auto_digest        — 昨日完整日记 → mem0 短期记忆（LLM 高质量提炼）
-02:00        auto_dream (AutoDream)  — 7天前短期记忆 → 升级或删除
+02:00        auto_dream (AutoDream)  — 步骤一：昨日日记 → 长期记忆（infer=True）；步骤二：7天前短期记忆 → 重新写入（infer=True）+ 删除
 ```
 
 ## 记忆分层：长期 vs 短期由谁决定？
@@ -92,7 +90,7 @@ mem0 本身没有长短期概念——默认永久保存所有写入的内容。
 | | 短期记忆 | 长期记忆 |
 |---|---|---|
 | **`run_id`** | `YYYY-MM-DD`（日期字符串） | 不传 |
-| **写入者** | `auto_digest.py`（自动） | Agent 主动写入、`memory_sync.py` 或 `auto_dream.py` / AutoDream 升级 |
+| **写入者** | `auto_digest.py`（自动） | Agent 主动写入、`memory_sync.py` 或 `auto_dream.py` / AutoDream（通过 infer=True 整合） |
 | **生命周期** | 7天后触发评估 | 永久保存 |
 | **典型内容** | 当天讨论、任务进展、临时决策 | 技术决策、经验教训、用户偏好 |
 
@@ -106,12 +104,11 @@ mem0 本身没有长短期概念——默认永久保存所有写入的内容。
 
 **路径二 — `auto_dream.py` / AutoDream**（每天，从短期记忆自动升级）
 
-7天后，对每条短期记忆进行评估：
-- 在过去 6 天的短期记忆中做语义搜索
-- 找到相似度 ≥ 0.75 的结果 → **升级**（重新写入，去掉 `run_id`）
-- 没有找到 → **删除**
+7天后，每条短期记忆以 `infer=True`（不传 `run_id`）重新写入 mem0。mem0 原生决策是 ADD（新知识）、UPDATE（与已有记忆合并）、DELETE（冗余）还是 NONE（无需操作）。然后删除原始短期条目。
 
-适合那些跨多天讨论、但未被明确记录到 `MEMORY.md` 的话题。
+同时在开始时执行步骤一：将昨日日记直接消化为长期记忆（infer=True，无 run_id），实现高质量的夜间知识提取。
+
+这取代了之前手写的语义搜索逻辑（is_topic_active），消除了数千次冗余的 Bedrock API 调用，转而利用 mem0 的原生智能。
 
 **路径三 — Agent 主动写入**（随时，按需）
 
@@ -149,6 +146,8 @@ run_id = 不传           →  长期记忆（永久保存）
 每天对昨天的完整日记运行一次。LLM 能看到整天发生的全部内容，产出质量更高、去重更彻底的记忆，而不是零散的片段。
 
 这提供了**高质量的回顾性记忆**，无需在每次增量写入时都调用 LLM。
+
+注意：自 PR #25 起，auto_dream 同时负责昨日日记的消化（步骤一）——之前 UTC 01:30 独立运行的 `auto_digest.py` 每日模式已被取代。
 
 ### 为什么 session_snapshot 不再写入 mem0
 


### PR DESCRIPTION
## 文档更新

同步 PR #25 的架构变更到 architecture.md（EN + ZH）。

### 更新内容

1. **Mermaid 流程图** — 去掉 Decision（Active?）分支，改为 Step1/Step2 两步流程
2. **Component 表格** — auto_dream 行描述更新为两步逻辑
3. **auto_digest --today** — 补充 infer=True 说明
4. **Pipeline Timeline** — auto_dream 描述更新
5. **Memory Tiering 表格** — Long-term Written by 描述
6. **Path 2 — AutoDream** — 重写为 re-add + infer=True 逻辑，删除手写语义比对描述
7. **Layer 2 Design Philosophy** — 补充说明 auto_dream 现在承担昨日日记提炼职责