### PR TITLE
docs: remove UTC 01:30 DigestFull references - superseded by auto_dream Step1

### DIFF
--- a/docs/guide/how-it-works.md
+++ b/docs/guide/how-it-works.md
@@ -87,11 +87,12 @@ On every heartbeat tick, the agent performs memory maintenance in order:
               ┌─────────────┼──────────────┬──────────────┐
               │             │              │              │
               ▼             ▼              ▼              ▼
-         Heartbeat      Every 15min    UTC 01:30      UTC 01:00
-         (agent         auto_digest    auto_digest    memory_sync
-          self-         --today        (full mode,    (sync
-          distills)     (incremental,  LLM extract    MEMORY.md)
-                        direct write)  yesterday)
+         Heartbeat      Every 15min    UTC 02:00      UTC 01:00
+         (agent         auto_digest    auto_dream     memory_sync
+          self-         --today        (Step1:        (sync
+          distills)     (infer=True,   yesterday      MEMORY.md)
+                        mem0 dedup)    diary +
+                                       Step2: 7d STM)
               │             │              │              │
               ▼             ▼              ▼              ▼
          MEMORY.md     mem0 short-    mem0 short-    mem0 long-
@@ -119,23 +120,20 @@ All automation runs as systemd user timers:
 | Every 5 min | `pipelines/session_snapshot.py` | Capture session conversations → diary file |
 | Every 15 min | `pipelines/auto_digest.py --today` | Incremental: read new diary content → mem0 short-term (infer=True, mem0 handles dedup) |
 | 01:00 | `pipelines/memory_sync.py` | Sync `MEMORY.md` → mem0 long-term (hash dedup) |
-| 01:30 | `pipelines/auto_digest.py` | Full mode: LLM-extract yesterday's complete diary → mem0 short-term |
 | 02:00 | `pipelines/auto_dream.py` | **AutoDream**: Step 1: yesterday diary → mem0 long-term (infer=True); Step 2: 7-day-old short-term → re-add to long-term (infer=True) then delete |
 
-## Two Modes of auto_digest
+## auto_digest Mode
 
-`auto_digest.py` runs in two different modes:
+`auto_digest.py` runs in one active mode:
 
 **`--today` mode (every 15 min, incremental)**
 Picks up new content from today's diary since the last run (offset-based). Writes to mem0 short-term memory with `infer=True` — mem0 handles fact extraction and deduplication automatically. Skips batches smaller than 500 bytes to avoid noisy micro-writes. On failure, retains the offset so the next run resumes from the same point.
 
-**Default mode (UTC 01:30, full)**
-Reads yesterday's complete diary, calls a local Bedrock LLM (Claude Haiku) to extract meaningful short-term events, and writes each event individually to mem0. Higher quality output than incremental mode; acts as a cleanup pass to catch anything the 15-min incremental runs may have missed.
-
 ```
 Every 15 min (--today):  diary new content → POST to mem0 (infer=True, mem0 dedup)
-UTC 01:30 (default):     yesterday's full diary → LLM extract → mem0
 ```
+
+> **Note**: The previous default full mode (UTC 01:30, LLM-extract yesterday's diary → mem0 short-term) has been superseded by `auto_dream.py` Step 1, which writes directly to long-term memory (no run_id) with higher quality.
 
 ## Two Roles of session_snapshot
 
@@ -195,30 +193,30 @@ When a new session starts, the skill instructs the agent to read **both diary fi
 Session start
   ├── Read memory/today.md      ← today's raw diary (real-time, not yet in mem0)
   ├── Read memory/yesterday.md  ← yesterday's raw diary (coverage gap buffer)
-  └── Search mem0 --combined    ← distilled memories (T+1 after 01:30 digest)
+  └── Search mem0 --combined    ← distilled memories (long-term + recent short-term)
 ```
 
 **Why today's diary?**
-`auto_digest.py` runs at UTC 01:30, processing *yesterday's* complete diary. Anything that happened today hasn't been digested yet — it only exists in `memory/today.md`. Reading this file is the only way to recover same-day context after a session reset.
+`auto_dream.py` Step 1 runs at UTC 02:00, digesting *yesterday's* complete diary. Anything that happened today hasn't been digested yet — it only exists in `memory/today.md`. Reading this file is the only way to recover same-day context after a session reset.
 
 **Why yesterday's diary?**
-There is a coverage gap: the window between yesterday's late-night conversations and when `auto_digest` finishes running (UTC 01:30). For example:
+There is a coverage gap: the window between yesterday's late-night conversations and when `auto_dream` finishes running (UTC 02:00). For example:
 
 ```
 Yesterday 23:50  Important discussion happens → written to memory/yesterday.md
 Today     00:10  Session resets, new session starts
-Today     01:30  auto_digest runs → yesterday's diary enters mem0
+Today     02:00  auto_dream runs → yesterday's diary enters mem0 long-term
 ```
 
-If the new session starts before 01:30, mem0 doesn't have last night's content yet. Reading `memory/yesterday.md` directly covers this gap.
+If the new session starts before 02:00, mem0 doesn't have last night's content yet. Reading `memory/yesterday.md` directly covers this gap.
 
 **The complete coverage map:**
 
 | Time window | Covered by |
 |-------------|------------|
 | Today (T+0) | `memory/today.md` (real-time) |
-| Yesterday after-midnight to 01:30 | `memory/yesterday.md` (gap buffer) |
-| Yesterday 01:30 onward | mem0 short-term (distilled) |
+| Yesterday after-midnight to 02:00 | `memory/yesterday.md` (gap buffer) |
+| Yesterday 02:00 onward | mem0 long-term (AutoDream Step1 digested) |
 | Last 7 days | mem0 short-term (`--combined`) |
 | Older than 7 days | mem0 long-term (AutoDream-consolidated) |
 

--- a/docs/zh/guide/how-it-works.md
+++ b/docs/zh/guide/how-it-works.md
@@ -87,11 +87,11 @@ Agent 读到「🔴 Agent Memory Behavior」规则
               ┌─────────────┼──────────────┬──────────────┐
               │             │              │              │
               ▼             ▼              ▼              ▼
-          Heartbeat      每 15 分钟     UTC 01:30      UTC 01:00
-          （agent        auto_digest   auto_digest    memory_sync
-           自我提炼）    --today       （全量模式，    （同步
-                         (增量，        LLM 提取       MEMORY.md）
-                          直接写入）     昨日日记）
+          Heartbeat      每 15 分钟     UTC 02:00      UTC 01:00
+          （agent        auto_digest   auto_dream     memory_sync
+           自我提炼）    --today       （Step1:        （同步
+                         (infer=True,   昨日日记 +     MEMORY.md）
+                          mem0 去重）    Step2: 7天STM）
               │             │              │              │
               ▼             ▼              ▼              ▼
           MEMORY.md     mem0 短期记忆  mem0 短期记忆  mem0 长期记忆
@@ -119,23 +119,20 @@ Agent 读到「🔴 Agent Memory Behavior」规则
 | 每 5 分钟 | `pipelines/session_snapshot.py` | 捕获会话对话 → 日记文件 |
 | 每 15 分钟 | `pipelines/auto_digest.py --today` | 增量模式：读取日记新增内容 → mem0 短期记忆（infer=True，mem0 自动去重） |
 | 01:00 | `pipelines/memory_sync.py` | 同步 `MEMORY.md` → mem0 长期记忆（hash 去重） |
-| 01:30 | `pipelines/auto_digest.py` | 全量模式：LLM 提取昨日完整日记 → mem0 短期记忆 |
 | 02:00 | `pipelines/auto_dream.py` | **AutoDream**：Step1: 昨日日记 → mem0 长期记忆（infer=True）；Step2: 7天前短期记忆 → re-add 到长期（infer=True）后删除 |
 
-## auto_digest 的两种模式
+## auto_digest 模式
 
-`auto_digest.py` 以两种不同模式运行：
+`auto_digest.py` 只有一种活跃模式：
 
 **`--today` 增量模式（每 15 分钟）**
 基于 offset 记录，每次只读取日记文件自上次运行以来的新增内容。以 `infer=True` 写入 mem0，由 mem0 自动做 fact extraction 和去重。新增内容不足 500 字节时跳过，避免无意义的小写入。写入失败时保留 offset，下次从同一断点续传。
 
-**默认全量模式（UTC 01:30）**
-读取昨天的完整日记文件，调用本地 Bedrock LLM（Claude Haiku）提取有意义的短期事件，逐条写入 mem0。输出质量高于增量模式，同时作为兜底——补齐 15 分钟增量模式可能遗漏的内容。
-
 ```
 每 15 分钟 (--today)：  日记新增内容 → POST 给 mem0（infer=True，mem0 去重）
-UTC 01:30 (默认)：      昨日完整日记 → LLM 提取 → mem0
 ```
+
+> **注**：之前的默认全量模式（UTC 01:30，LLM 提取昨日日记 → mem0 短期记忆）已被 `auto_dream.py` Step 1 取代——后者直接写入长期记忆（无 run_id），质量更高。
 
 ## session_snapshot 的两个角色
 
@@ -195,30 +192,30 @@ python3 cli.py add \
 Session 启动
   ├── 读 memory/今天.md      ← 今天的原始日记（实时，尚未进 mem0）
   ├── 读 memory/昨天.md      ← 昨天的原始日记（覆盖时间窗口盲区）
-  └── search mem0 --combined ← 提炼后的记忆（T+1，01:30 之后）
+  └── search mem0 --combined ← 提炼后的记忆（长期 + 近期短期记忆）
 ```
 
 **为什么要读今天的日记？**
-`auto_digest.py` 在 UTC 01:30 运行，处理的是*昨天*的完整日记。今天发生的所有事情还没有被提炼——只存在于 `memory/今天.md` 里。Session 重置后，读这个文件是恢复当天上下文的唯一途径。
+`auto_dream.py` Step 1 在 UTC 02:00 运行，处理的是*昨天*的完整日记。今天发生的所有事情还没有被提炼——只存在于 `memory/今天.md` 里。Session 重置后，读这个文件是恢复当天上下文的唯一途径。
 
 **为什么要读昨天的日记？**
-存在一个覆盖盲区：昨天深夜的对话，到 `auto_digest` 完成运行（UTC 01:30）之间的时间窗口。例如：
+存在一个覆盖盲区：昨天深夜的对话，到 `auto_dream` 完成运行（UTC 02:00）之间的时间窗口。例如：
 
 ```
 昨天 23:50  发生了重要讨论 → 写入 memory/昨天.md
 今天 00:10  Session 重置，新 session 启动
-今天 01:30  auto_digest 运行 → 昨天日记进入 mem0
+今天 02:00  auto_dream 运行 → 昨天日记进入 mem0 长期记忆
 ```
 
-如果新 session 在 01:30 之前启动，mem0 里还没有昨晚的内容。直接读 `memory/昨天.md` 可以覆盖这个盲区。
+如果新 session 在 02:00 之前启动，mem0 里还没有昨晚的内容。直接读 `memory/昨天.md` 可以覆盖这个盲区。
 
 **完整的时间覆盖地图：**
 
 | 时间窗口 | 覆盖手段 |
 |---------|---------|
 | 今天（T+0） | `memory/今天.md`（实时） |
-| 昨天深夜到今天 01:30 | `memory/昨天.md`（盲区缓冲） |
-| 昨天 01:30 之后 | mem0 短期记忆（已提炼） |
+| 昨天深夜到今天 02:00 | `memory/昨天.md`（盲区缓冲） |
+| 昨天 02:00 之后 | mem0 长期记忆（AutoDream Step1 提炼） |
 | 最近 7 天 | mem0 短期记忆（`--combined`） |
 | 7 天以上 | mem0 长期记忆（AutoDream 整合后） |
 


### PR DESCRIPTION
## 文档修复

移除所有 UTC 01:30 / auto_digest full mode / DigestFull 相关描述，与现在实际运行的架构对齐。

### 背景
auto_digest 全量模式（UTC 01:30）已被 auto_dream Step1 取代，但 how-it-works.md 中仍有大量残留引用。

### 修改内容（how-it-works.md EN + ZH）

1. **流程图** — UTC 01:30 列改为 UTC 02:00 auto_dream（Step1+Step2）
2. **每日时序表** — 删除 01:30 auto_digest 行
3. **"Two Modes of auto_digest" → "auto_digest Mode"** — 删除 Default full mode 描述，改为一种模式 + Note 说明被取代
4. **Session 覆盖图** — 01:30 时间点全部改为 02:00，short-term 改为 long-term
5. **Coverage map 表格** — 更新时间窗口和覆盖手段