### PR TITLE
docs: completely rewrite architecture.md - remove DigestFull, align with current pipeline

### DIFF
--- a/docs/guide/architecture.md
+++ b/docs/guide/architecture.md
@@ -1,6 +1,6 @@
 # Architecture
 
-The mem0 Memory Service acts as the central memory layer for all OpenClaw agents. It receives session data through a pipeline (snapshot → digest → archive), distills it into semantic memories using AWS Bedrock, and serves relevant context back to agents on demand.
+The mem0 Memory Service acts as the central memory layer for all OpenClaw agents. It receives session data through a pipeline (snapshot → digest → dream), distills it into semantic memories using AWS Bedrock, and serves relevant context back to agents on demand.
 
 ```mermaid
 flowchart TD
@@ -15,9 +15,8 @@ flowchart TD
     MemoryMD["MEMORY.md\n(agent curated knowledge)"]
     Snap(["session_snapshot.py\n(every 5 min, diary only)"])
     DigestToday(["auto_digest.py --today\n(every 15 min, infer=True, mem0 dedup)"])
-    DigestFull(["auto_digest.py\n(daily UTC 01:30, yesterday full)"])
-    Sync(["memory_sync.py\n(daily, MEMORY.md)"])
-    Archive(["auto_dream.py\n(AutoDream)"])
+    Sync(["memory_sync.py\n(daily UTC 01:00, MEMORY.md)"])
+    Archive(["auto_dream.py\n(AutoDream, UTC 02:00)"])
 
     subgraph Mem0["mem0 Memory Service"]
         LLM(["AWS Bedrock LLM\n(distill / deduplicate)"])
@@ -25,7 +24,6 @@ flowchart TD
         STM["Short-term Memory\n(run_id = date)"]
         LTM["Long-term Memory\n(no run_id)"]
     end
-
 
     subgraph Store["Vector Store"]
         S3[("S3 Vectors")]
@@ -39,11 +37,9 @@ flowchart TD
     Agents -- "active write\n(no run_id)" --> LTM
     Agents -- "actively maintain" --> MemoryMD
     Snap --> Diary
-    Diary -- "every 15 min\n(50KB batches, direct write)" --> DigestToday
-    Diary -- "daily UTC 01:30\n(yesterday full diary, LLM distill)" --> DigestFull
+    Diary -- "every 15 min\n(50KB batches, infer=True)" --> DigestToday
     MemoryMD -- "daily UTC 01:00\n(hash dedup)" --> Sync
     DigestToday --> STM
-    DigestFull --> STM
     Sync --> LTM
     STM -- "daily UTC 02:00\n(7-day-old entries)" --> Archive
     Archive -- "Step 1: yesterday diary\n(infer=True)" --> LTM
@@ -66,9 +62,8 @@ flowchart TD
 |---|---|
 | **session_snapshot.py** | Runs every 5 minutes. Captures **all** agent sessions (direct chat + group chats) into daily diary files. **Does not write to mem0 directly** — mem0 ingestion is handled entirely by auto_digest. |
 | **auto_digest.py --today** | Runs every 15 minutes. Reads only the **new bytes** added since the last run (tracked via `auto_digest_offset.json`). Sends content to mem0 in **section-aligned batches** (up to ~50KB each, aligned to `## ` diary section boundaries) with `infer=True` — mem0 handles fact extraction and deduplication automatically. Offset is persisted after each successful batch, enabling crash-safe resume. |
-| **auto_digest.py** (daily) | Runs daily at UTC 01:30. Processes **yesterday's complete diary** in one pass using LLM distillation — higher quality extraction with full-day context. Writes to mem0 as short-term memories (`run_id=date`). |
 | **memory_sync.py** | Runs daily at UTC 01:00. Syncs each agent's `MEMORY.md` (curated knowledge) directly to mem0 long-term memory. Hash-based dedup skips unchanged files — zero LLM cost if nothing changed. |
-| **auto_dream.py** / **AutoDream** | Runs daily at UTC 02:00. **Step 1**: digests yesterday's diary into long-term memory (infer=True, no run_id). **Step 2**: for each 7-day-old short-term memory, re-adds it to mem0 with infer=True (no run_id) — mem0 natively decides ADD/UPDATE/DELETE/NONE — then deletes the original short-term entry. |
+| **auto_dream.py** / **AutoDream** | Runs daily at UTC 02:00. **Step 1**: reads yesterday's complete diary → `mem0.add(infer=True, no run_id)` → long-term memory. **Step 2**: for each 7-day-old short-term memory, re-adds it to mem0 with `infer=True` (no run_id) — mem0 natively decides ADD/UPDATE/DELETE/NONE — then deletes the original short-term entry. |
 | **mem0 Memory Service** | Core service. Uses AWS Bedrock LLM for memory distillation/deduplication and Bedrock Embedding for vectorization. |
 | **Vector Store** | Persists memory vectors. Supports S3 Vectors or OpenSearch as the backend. |
 | **SKILL.md → Retrieval** | On new agent sessions, reads SKILL.md, queries mem0 for relevant memories, and injects them as context. |
@@ -76,11 +71,11 @@ flowchart TD
 ## Pipeline Timeline (UTC)
 
 ```
-Every 5 min   session_snapshot  — conversations → diary files  (no mem0 write)
-Every 15 min  auto_digest --today — diary new bytes → mem0 short-term  (real-time, batched)
-01:00         memory_sync       — MEMORY.md → mem0 long-term  (curated knowledge, instant)
-01:30         auto_digest       — yesterday's diary → mem0 short-term  (full-day LLM distill)
-02:00         auto_dream (AutoDream)           — Step1: yesterday diary → long-term (infer=True); Step2: 7-day-old short-term → re-add (infer=True) + delete
+Every 5 min   session_snapshot    — conversations → diary files  (no mem0 write)
+Every 15 min  auto_digest --today — diary new bytes → mem0 short-term  (infer=True, mem0 dedup)
+01:00         memory_sync         — MEMORY.md → mem0 long-term  (curated knowledge, instant)
+02:00         auto_dream          — Step1: yesterday diary → long-term (infer=True)
+                                    Step2: 7-day-old short-term → re-add (infer=True) + delete
 ```
 
 ## Memory Tiering: Who Decides Long vs. Short-Term?
@@ -90,25 +85,26 @@ mem0 itself has no concept of short-term or long-term — it stores everything p
 | | Short-term | Long-term |
 |---|---|---|
 | **`run_id`** | `YYYY-MM-DD` (date string) | absent |
-| **Written by** | `auto_digest.py` (automated) | Agent explicitly, `memory_sync.py`, or `auto_dream.py` / AutoDream (consolidated via infer=True) |
-| **Lifetime** | 7 days → evaluated for promotion | Permanent |
+| **Written by** | `auto_digest.py --today` (automated) | Agent explicitly, `memory_sync.py`, or `auto_dream.py` / AutoDream (consolidated via infer=True) |
+| **Lifetime** | 7 days → consolidated by auto_dream | Permanent |
 | **Typical content** | Daily discussions, task progress, temp decisions | Tech decisions, lessons learned, user preferences |
 
 ### Three paths to long-term memory
 
-**Path 1 — `memory_sync.py`** (daily, from `MEMORY.md`)
+**Path 1 — `memory_sync.py`** (daily UTC 01:00, from `MEMORY.md`)
 
 Each agent's `MEMORY.md` is the highest-quality memory source — curated directly by the agent during heartbeats. `memory_sync.py` syncs it to mem0 long-term memory every day at UTC 01:00, with hash-based dedup to avoid redundant LLM calls.
 
 This is the **fastest path**: important decisions and lessons reach long-term memory the same day, without waiting for the 7-day archive cycle.
 
-**Path 2 — `auto_dream.py` / AutoDream** (daily, automatic promotion from short-term)
+**Path 2 — `auto_dream.py` / AutoDream** (daily UTC 02:00)
 
-After 7 days, each short-term memory is re-added to mem0 with `infer=True` (without `run_id`). mem0 natively decides whether to ADD (new knowledge), UPDATE (merge with existing), DELETE (redundant), or NONE (no action needed). The original short-term entry is then deleted.
+Runs two steps each night:
 
-Also runs Step 1 at the start: digests yesterday's diary directly into long-term memory (infer=True, no run_id) for high-quality nightly knowledge extraction.
+- **Step 1**: Reads yesterday's complete diary and writes it to mem0 with `infer=True` (no `run_id`) — directly into long-term memory with full-day context for high-quality extraction.
+- **Step 2**: For each 7-day-old short-term memory, re-adds it to mem0 with `infer=True` (no `run_id`). mem0 natively decides whether to ADD (new knowledge), UPDATE (merge with existing), DELETE (redundant), or NONE (no action). The original short-term entry is then deleted.
 
-This replaces the previous hand-written semantic search (is_topic_active), eliminating thousands of redundant Bedrock API calls and leveraging mem0's native intelligence instead.
+This leverages mem0's native intelligence instead of hand-written semantic search, eliminating thousands of redundant Bedrock API calls per run.
 
 **Path 3 — Agent explicit write** (on-demand)
 
@@ -131,23 +127,19 @@ run_id = absent          →  long-term  (permanent)
 
 ## Design Philosophy
 
-### Two-layer diary-to-mem0 pipeline
+### Diary-to-mem0 pipeline
 
-The diary → mem0 pipeline uses two complementary passes:
+**`auto_digest.py --today` (every 15 min, incremental)**
 
-**Layer 1 — `auto_digest.py --today` (every 15 min, incremental)**
+Runs every 15 minutes, reading only new diary content since the last run. Sends **section-aligned batches** (up to ~50KB each, aligned to `## ` diary section boundaries) to mem0 with `infer=True` — mem0 handles fact extraction and deduplication automatically. Offset is saved after each successful batch — if the process is interrupted, the next run picks up where it left off.
 
-Runs every 15 minutes, reading only new diary content since the last run. Sends **section-aligned batches** (up to ~50KB each, aligned to `## ` diary section boundaries) directly to mem0, letting mem0's own fact extraction handle distillation. Offset is saved after each successful batch — if the process is interrupted, the next run picks up where it left off.
+This provides **real-time cross-session memory**: conversations from the last ~15 minutes are available for retrieval in other sessions of the same agent.
 
-This provides **real-time memory**: conversations from the last 15 minutes are available for retrieval within the same day.
+**`auto_dream.py` Step 1 (UTC 02:00, yesterday diary → long-term)**
 
-**Layer 2 — `auto_digest.py` (daily, full LLM distill)**
+Runs once per day. Reads yesterday's complete diary and writes it to mem0 with `infer=True` (no `run_id`) — directly as long-term memory. With the full day's context available, mem0 produces higher-quality, deduplicated memories.
 
-Runs once per day on yesterday's complete diary. With the full day's context available, the LLM produces higher-quality, deduplicated memories that capture the day's overall arc rather than isolated fragments.
-
-This provides **high-quality retrospective memory** without the cost of running LLM on every incremental batch.
-
-Note: Since PR #25, auto_dream also handles yesterday diary digestion (Step 1) — the previous standalone `auto_digest.py` daily mode at UTC 01:30 has been superseded.
+This provides **high-quality nightly long-term memory** from the full day's context.
 
 ### Why session_snapshot no longer writes to mem0
 

--- a/docs/zh/guide/architecture.md
+++ b/docs/zh/guide/architecture.md
@@ -15,9 +15,8 @@ flowchart TD
     MemoryMD["MEMORY.md\n（Agent 精选知识库）"]
     Snap(["session_snapshot.py\n（每 5 分钟，仅写日记）"])
     DigestToday(["auto_digest.py --today\n（每 15 分钟，infer=True，mem0 去重）"])
-    DigestFull(["auto_digest.py\n（每天 UTC 01:30，昨日全量）"])
-    Sync(["memory_sync.py\n（每天，同步 MEMORY.md）"])
-    Archive(["auto_dream.py\n(AutoDream)"])
+    Sync(["memory_sync.py\n（每天 UTC 01:00，同步 MEMORY.md）"])
+    Archive(["auto_dream.py\n(AutoDream，UTC 02:00)"])
 
     subgraph Mem0["mem0 Memory Service"]
         LLM(["AWS Bedrock LLM\n（记忆提炼/去重）"])
@@ -25,7 +24,6 @@ flowchart TD
         STM["短期记忆\n（run_id = 日期）"]
         LTM["长期记忆\n（无 run_id）"]
     end
-
 
     subgraph Store["向量存储"]
         S3[("S3 Vectors")]
@@ -39,11 +37,9 @@ flowchart TD
     Agents -- "主动写入\n（无 run_id）" --> LTM
     Agents -- "主动维护" --> MemoryMD
     Snap --> Diary
-    Diary -- "每 15 分钟\n（50KB 分批，直接写入）" --> DigestToday
-    Diary -- "每天 UTC 01:30\n（昨日完整日记，LLM 提炼）" --> DigestFull
+    Diary -- "每 15 分钟\n（50KB 分批，infer=True）" --> DigestToday
     MemoryMD -- "每天 UTC 01:00\n（hash 去重）" --> Sync
     DigestToday --> STM
-    DigestFull --> STM
     Sync --> LTM
     STM -- "每天 UTC 02:00\n（7天前条目）" --> Archive
     Archive -- "步骤一：昨日日记\n（infer=True）" --> LTM
@@ -64,11 +60,10 @@ flowchart TD
 
 | 组件 | 职责 |
 |---|---|
-| **session_snapshot.py** | 每 5 分钟运行一次。捕获**所有** Agent 会话（单聊 + 群聊）到日记文件。**不再直接写入 mem0**——mem0 的写入完全由 auto_digest 负责。 |
-| **auto_digest.py --today** | 每 15 分钟运行一次。读取自上次运行以来日记文件中的**新增字节**（通过 `auto_digest_offset.json` 追踪），以**按 `## ` 章节边界对齐的分批**方式（每批最大约 50KB）发送给 mem0，使用 `infer=True`——mem0 自动处理事实提取和去重。每批成功后立即持久化 offset，支持断点续传。 |
-| **auto_digest.py**（每日） | 每天 UTC 01:30 运行。通过 LLM 提炼**昨天的完整日记**，一次性处理——利用全天完整上下文产出更高质量的记忆。写入 mem0 短期记忆（`run_id=日期`）。 |
-| **memory_sync.py** | 每天 UTC 01:00 运行。将各 Agent 的 `MEMORY.md`（精选知识）直接同步到 mem0 长期记忆。基于内容 hash 去重，文件未变化时零 LLM 调用。 |
-| **auto_dream.py** / **AutoDream** | 每天 UTC 02:00 运行。**步骤一**：将昨日日记消化为长期记忆（infer=True，无 run_id）。**步骤二**：对每条 7 天前的短期记忆，以 infer=True（无 run_id）重新写入 mem0——mem0 原生决策 ADD/UPDATE/DELETE/NONE——然后删除原始短期条目。 |
+| **session_snapshot.py** | 每 5 分钟运行一次。捕获**所有** Agent 会话（单聊 + 群聊）到日记文件。**不直接写入 mem0**——mem0 的写入完全由 auto_digest 负责。 |
+| **auto_digest.py --today** | 每 15 分钟运行一次。读取自上次运行以来日记文件中的**新增字节**（通过 `auto_digest_offset.json` 追踪），以**按 `## ` 章节边界对齐的分批**（每批最大约 50KB）加 `infer=True` 写入 mem0——mem0 自动处理事实提取和去重。每批成功后立即持久化 offset，支持断点续传。 |
+| **memory_sync.py** | 每天 UTC 01:00 运行。将各 Agent 的 `MEMORY.md`（精选知识）直接同步到 mem0 长期记忆。基于 hash 去重，文件未变化时零 LLM 调用。 |
+| **auto_dream.py** / **AutoDream** | 每天 UTC 02:00 运行。**步骤一**：读取昨日完整日记 → `mem0.add(infer=True, 无 run_id)` → 长期记忆。**步骤二**：对每条 7 天前的短期记忆，以 `infer=True`（无 run_id）重新写入 mem0——mem0 原生决策 ADD/UPDATE/DELETE/NONE——然后删除原始短期条目。 |
 | **mem0 Memory Service** | 核心服务。使用 AWS Bedrock LLM 进行记忆提炼与去重，使用 Bedrock Embedding 进行向量化。 |
 | **向量存储** | 持久化记忆向量，支持 S3 Vectors 或 OpenSearch 作为后端。 |
 | **SKILL.md → 检索** | Agent 新会话启动时，读取 SKILL.md，查询 mem0 获取相关记忆，注入为上下文。 |
@@ -76,11 +71,11 @@ flowchart TD
 ## 流水线时序（UTC）
 
 ```
-每 5 分钟    session_snapshot   — 对话 → 日记文件（不写 mem0）
-每 15 分钟   auto_digest --today — 日记新增内容 → mem0 短期记忆（实时，分批写入）
-01:00        memory_sync        — MEMORY.md → mem0 长期记忆（精选知识，即时生效）
-01:30        auto_digest        — 昨日完整日记 → mem0 短期记忆（LLM 高质量提炼）
-02:00        auto_dream (AutoDream)  — 步骤一：昨日日记 → 长期记忆（infer=True）；步骤二：7天前短期记忆 → 重新写入（infer=True）+ 删除
+每 5 分钟    session_snapshot    — 对话 → 日记文件（不写 mem0）
+每 15 分钟   auto_digest --today — 日记新增内容 → mem0 短期记忆（infer=True，mem0 去重）
+01:00        memory_sync         — MEMORY.md → mem0 长期记忆（精选知识，即时生效）
+02:00        auto_dream          — 步骤一：昨日日记 → 长期记忆（infer=True）
+                                   步骤二：7天前短期记忆 → 重新写入（infer=True）+ 删除
 ```
 
 ## 记忆分层：长期 vs 短期由谁决定？
@@ -90,25 +85,26 @@ mem0 本身没有长短期概念——默认永久保存所有写入的内容。
 | | 短期记忆 | 长期记忆 |
 |---|---|---|
 | **`run_id`** | `YYYY-MM-DD`（日期字符串） | 不传 |
-| **写入者** | `auto_digest.py`（自动） | Agent 主动写入、`memory_sync.py` 或 `auto_dream.py` / AutoDream（通过 infer=True 整合） |
-| **生命周期** | 7天后触发评估 | 永久保存 |
+| **写入者** | `auto_digest.py --today`（自动） | Agent 主动写入、`memory_sync.py` 或 `auto_dream.py` / AutoDream（infer=True 整合） |
+| **生命周期** | 7天后由 auto_dream 整合 | 永久保存 |
 | **典型内容** | 当天讨论、任务进展、临时决策 | 技术决策、经验教训、用户偏好 |
 
 ### 进入长期记忆的三条路径
 
-**路径一 — `memory_sync.py`**（每天，来自 `MEMORY.md`）
+**路径一 — `memory_sync.py`**（每天 UTC 01:00，来自 `MEMORY.md`）
 
 每个 Agent 的 `MEMORY.md` 是质量最高的记忆来源——Agent 在 heartbeat 时主动维护，是其所学知识的精华提炼。`memory_sync.py` 每天 UTC 01:00 将其同步到 mem0 长期记忆，基于 hash 去重避免重复 LLM 调用。
 
 这是**最快的路径**：重要决策和经验教训当天就能进入长期记忆，无需等待 7 天归档周期。
 
-**路径二 — `auto_dream.py` / AutoDream**（每天，从短期记忆自动升级）
+**路径二 — `auto_dream.py` / AutoDream**（每天 UTC 02:00）
 
-7天后，每条短期记忆以 `infer=True`（不传 `run_id`）重新写入 mem0。mem0 原生决策是 ADD（新知识）、UPDATE（与已有记忆合并）、DELETE（冗余）还是 NONE（无需操作）。然后删除原始短期条目。
+每晚执行两个步骤：
 
-同时在开始时执行步骤一：将昨日日记直接消化为长期记忆（infer=True，无 run_id），实现高质量的夜间知识提取。
+- **步骤一**：读取昨日完整日记，以 `infer=True`（无 `run_id`）写入 mem0——直接进入长期记忆，利用全天完整上下文提取高质量知识。
+- **步骤二**：对每条 7 天前的短期记忆，以 `infer=True`（无 `run_id`）重新写入 mem0。mem0 原生决策是 ADD（新知识）、UPDATE（合并已有记忆）、DELETE（冗余）还是 NONE（无需操作），然后删除原始短期条目。
 
-这取代了之前手写的语义搜索逻辑（is_topic_active），消除了数千次冗余的 Bedrock API 调用，转而利用 mem0 的原生智能。
+利用 mem0 原生智能，取代了之前手写的语义搜索逻辑，消除了每次运行数千次冗余的 Bedrock API 调用。
 
 **路径三 — Agent 主动写入**（随时，按需）
 
@@ -131,23 +127,19 @@ run_id = 不传           →  长期记忆（永久保存）
 
 ## 设计理念
 
-### 日记到 mem0 的两层流水线
+### 日记到 mem0 的流水线
 
-日记 → mem0 的流水线采用两个互补的处理层：
+**`auto_digest.py --today`（每 15 分钟，增量）**
 
-**第一层 — `auto_digest.py --today`（每 15 分钟，增量）**
+每 15 分钟运行一次，只读取自上次运行以来的新增内容。以**按 `## ` 章节边界对齐的分批**（每批最大约 50KB）加 `infer=True` 发给 mem0——mem0 自动做 fact extraction 和去重。每批成功后立即保存 offset——即使进程中断，下次运行也能从断点继续。
 
-每 15 分钟运行一次，只读取自上次运行以来的新增内容。以**按 `## ` 章节边界对齐的分批**方式（每批最大约 50KB）直接发给 mem0，由 mem0 内部做 fact extraction，避免在段落中间截断上下文。每批成功后立即保存 offset——即使进程中断，下次运行也能从断点继续。
+这提供了**实时跨 session 记忆**：最近 ~15 分钟的对话可在同一 agent 的其他 session 中被检索到。
 
-这提供了**实时记忆**：最近 15 分钟的对话当天即可被检索到。
+**`auto_dream.py` 步骤一（UTC 02:00，昨日日记 → 长期记忆）**
 
-**第二层 — `auto_digest.py`（每天，全量 LLM 提炼）**
+每天运行一次。读取昨日完整日记，以 `infer=True`（无 `run_id`）写入 mem0——直接进入长期记忆。利用全天完整上下文，mem0 提取质量更高、去重更彻底的知识。
 
-每天对昨天的完整日记运行一次。LLM 能看到整天发生的全部内容，产出质量更高、去重更彻底的记忆，而不是零散的片段。
-
-这提供了**高质量的回顾性记忆**，无需在每次增量写入时都调用 LLM。
-
-注意：自 PR #25 起，auto_dream 同时负责昨日日记的消化（步骤一）——之前 UTC 01:30 独立运行的 `auto_digest.py` 每日模式已被取代。
+这提供了**高质量的夜间长期记忆**，充分利用整天的完整上下文。
 
 ### 为什么 session_snapshot 不再写入 mem0
 


### PR DESCRIPTION
## 彻底重写 architecture.md（EN + ZH）

PR #26 只加了 Note，没有真正删掉旧内容。本 PR 直接重写两个文件，彻底清除所有已废弃的描述。

### 删除内容
- Mermaid 流程图中的 `DigestFull` 节点和连线
- Component 表格中的 `auto_digest.py (daily)` 行
- Pipeline Timeline 中的 `01:30` 行
- Design Philosophy 中的 "Layer 2 auto_digest daily" 整段
- 所有 "direct write"、"UTC 01:30"、"yesterday full" 引用

### 新增/更新内容
- auto_dream 组件职责描述（Step1 + Step2）
- Pipeline Timeline 更新
- Design Philosophy 改为两节：auto_digest --today 增量 + auto_dream Step1 夜间
- 三条长期记忆路径中 Path 2 重写