### PR TITLE
fix: INTER_MEMORY_SLEEP 1.0s→0.2s; docs: clarify mem0 decision flow in auto_dream

### DIFF
--- a/docs/guide/architecture.md
+++ b/docs/guide/architecture.md
@@ -63,7 +63,7 @@ flowchart TD
 | **session_snapshot.py** | Runs every 5 minutes. Captures **all** agent sessions (direct chat + group chats) into daily diary files. **Does not write to mem0 directly** — mem0 ingestion is handled entirely by auto_digest. |
 | **auto_digest.py --today** | Runs every 15 minutes. Reads only the **new bytes** added since the last run (tracked via `auto_digest_offset.json`). Sends content to mem0 in **section-aligned batches** (up to ~50KB each, aligned to `## ` diary section boundaries) with `infer=True` — mem0 handles fact extraction and deduplication automatically. Offset is persisted after each successful batch, enabling crash-safe resume. |
 | **memory_sync.py** | Runs daily at UTC 01:00. Syncs each agent's `MEMORY.md` (curated knowledge) directly to mem0 long-term memory. Hash-based dedup skips unchanged files — zero LLM cost if nothing changed. |
-| **auto_dream.py** / **AutoDream** | Runs daily at UTC 02:00. **Step 1**: reads yesterday's complete diary → `mem0.add(infer=True, no run_id)` → long-term memory. **Step 2**: for each 7-day-old short-term memory, re-adds it to mem0 with `infer=True` (no run_id) — mem0 natively decides ADD/UPDATE/DELETE/NONE — then deletes the original short-term entry. |
+| **auto_dream.py** / **AutoDream** | Runs daily at UTC 02:00. **Step 1**: reads yesterday's complete diary → `mem0.add(infer=True, no run_id)` → long-term memory. **Step 2**: for each 7-day-old short-term memory, calls `mem0.add(infer=True, no run_id)` — mem0 LLM compares against existing long-term memories and returns a decision: `ADD` (new knowledge, write), `UPDATE` (merge with existing), `DELETE` (redundant, skip write), or `NONE` (already covered). Regardless of decision, the original short-term entry is always deleted after processing. |
 | **mem0 Memory Service** | Core service. Uses AWS Bedrock LLM for memory distillation/deduplication and Bedrock Embedding for vectorization. |
 | **Vector Store** | Persists memory vectors. Supports S3 Vectors or OpenSearch as the backend. |
 | **SKILL.md → Retrieval** | On new agent sessions, reads SKILL.md, queries mem0 for relevant memories, and injects them as context. |
@@ -102,7 +102,13 @@ This is the **fastest path**: important decisions and lessons reach long-term me
 Runs two steps each night:
 
 - **Step 1**: Reads yesterday's complete diary and writes it to mem0 with `infer=True` (no `run_id`) — directly into long-term memory with full-day context for high-quality extraction.
-- **Step 2**: For each 7-day-old short-term memory, re-adds it to mem0 with `infer=True` (no `run_id`). mem0 natively decides whether to ADD (new knowledge), UPDATE (merge with existing), DELETE (redundant), or NONE (no action). The original short-term entry is then deleted.
+- **Step 2**: For each 7-day-old short-term memory, calls `mem0.add(infer=True, no run_id)`. mem0's LLM compares the memory against existing long-term memories and returns one of four decisions:
+  - `ADD` — new knowledge → written as new long-term entry
+  - `UPDATE` — overlaps with existing → merged/updated
+  - `DELETE` — redundant or contradicted → write skipped
+  - `NONE` — already fully covered → write skipped
+
+  Regardless of the decision, the **original short-term entry is always deleted** after processing.
 
 This leverages mem0's native intelligence instead of hand-written semantic search, eliminating thousands of redundant Bedrock API calls per run.
 

--- a/docs/zh/guide/architecture.md
+++ b/docs/zh/guide/architecture.md
@@ -63,7 +63,7 @@ flowchart TD
 | **session_snapshot.py** | 每 5 分钟运行一次。捕获**所有** Agent 会话（单聊 + 群聊）到日记文件。**不直接写入 mem0**——mem0 的写入完全由 auto_digest 负责。 |
 | **auto_digest.py --today** | 每 15 分钟运行一次。读取自上次运行以来日记文件中的**新增字节**（通过 `auto_digest_offset.json` 追踪），以**按 `## ` 章节边界对齐的分批**（每批最大约 50KB）加 `infer=True` 写入 mem0——mem0 自动处理事实提取和去重。每批成功后立即持久化 offset，支持断点续传。 |
 | **memory_sync.py** | 每天 UTC 01:00 运行。将各 Agent 的 `MEMORY.md`（精选知识）直接同步到 mem0 长期记忆。基于 hash 去重，文件未变化时零 LLM 调用。 |
-| **auto_dream.py** / **AutoDream** | 每天 UTC 02:00 运行。**步骤一**：读取昨日完整日记 → `mem0.add(infer=True, 无 run_id)` → 长期记忆。**步骤二**：对每条 7 天前的短期记忆，以 `infer=True`（无 run_id）重新写入 mem0——mem0 原生决策 ADD/UPDATE/DELETE/NONE——然后删除原始短期条目。 |
+| **auto_dream.py** / **AutoDream** | 每天 UTC 02:00 运行。**步骤一**：读取昨日完整日记 → `mem0.add(infer=True, 无 run_id)` → 长期记忆。**步骤二**：对每条 7 天前的短期记忆，调用 `mem0.add(infer=True, 无 run_id)`——mem0 LLM 与已有长期记忆比对，返回四种决策之一：`ADD`（新知识，写入）、`UPDATE`（与已有条目合并）、`DELETE`（冗余，跳过写入）、`NONE`（已完全覆盖，跳过写入）。无论何种决策，**原始短期条目处理后始终删除**。 |
 | **mem0 Memory Service** | 核心服务。使用 AWS Bedrock LLM 进行记忆提炼与去重，使用 Bedrock Embedding 进行向量化。 |
 | **向量存储** | 持久化记忆向量，支持 S3 Vectors 或 OpenSearch 作为后端。 |
 | **SKILL.md → 检索** | Agent 新会话启动时，读取 SKILL.md，查询 mem0 获取相关记忆，注入为上下文。 |
@@ -102,7 +102,13 @@ mem0 本身没有长短期概念——默认永久保存所有写入的内容。
 每晚执行两个步骤：
 
 - **步骤一**：读取昨日完整日记，以 `infer=True`（无 `run_id`）写入 mem0——直接进入长期记忆，利用全天完整上下文提取高质量知识。
-- **步骤二**：对每条 7 天前的短期记忆，以 `infer=True`（无 `run_id`）重新写入 mem0。mem0 原生决策是 ADD（新知识）、UPDATE（合并已有记忆）、DELETE（冗余）还是 NONE（无需操作），然后删除原始短期条目。
+- **步骤二**：对每条 7 天前的短期记忆，调用 `mem0.add(infer=True, 无 run_id)`。mem0 LLM 将该条记忆与已有长期记忆比对，返回四种决策之一：
+  - `ADD` — 新知识 → 写入新的长期记忆条目
+  - `UPDATE` — 与已有条目重叠 → 合并/更新
+  - `DELETE` — 冗余或被已有知识覆盖 → 跳过写入
+  - `NONE` — 已完全覆盖 → 跳过写入
+
+  无论何种决策，**原始短期条目处理后始终删除**。
 
 利用 mem0 原生智能，取代了之前手写的语义搜索逻辑，消除了每次运行数千次冗余的 Bedrock API 调用。
 

--- a/pipelines/auto_dream.py
+++ b/pipelines/auto_dream.py
@@ -24,7 +24,7 @@ USER_ID = "boss"
 ARCHIVE_DAYS = 7
 MAX_MEMORIES_PER_RUN = 300
 MAX_CONSECUTIVE_ERRORS = 3
-INTER_MEMORY_SLEEP = 1.0
+INTER_MEMORY_SLEEP = 0.2  # mem0 串行处理，瓶颈在 Bedrock LLM (~6s/条)，0.2s 足够防止请求堆积
 LOG_FILE = Path(__file__).parent.parent / "auto_dream.log"
 
 OPENCLAW_BASE = Path(os.environ.get("OPENCLAW_HOME", Path.home() / ".openclaw"))


### PR DESCRIPTION
## 修改

**auto_dream.py**
- `INTER_MEMORY_SLEEP` 从 1.0s 降到 0.2s
- 瓶颈在 Bedrock LLM（~6s/条），sleep 只占 13%，auto_dream 是串行的，server 有 semaphore 限并发，0.2s 足够防止请求堆积
- 300条可节省约 4min 总耗时

**docs/guide/architecture.md + docs/zh/guide/architecture.md**
- 补充 mem0 四种决策的含义（ADD/UPDATE/DELETE/NONE）
- 明确「无论何种决策，原始短期条目处理后始终删除」