### PR TITLE
feat(search): min_score filter + reduce default top_k/recent_days

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -169,15 +169,16 @@ def main():
     p_search.add_argument("--agent", default=None)
     p_search.add_argument("--run", default=None, help="Filter by specific run ID")
     p_search.add_argument("--query", required=True)
-    p_search.add_argument("--top-k", type=int, default=10)
+    p_search.add_argument("--top-k", type=int, default=5,
+                          help="Max results to return (default: 5)")
     p_search.add_argument("--min-score", type=float, default=0.0,
                           help="Minimum relevance score to include (0.0–1.0). "
                                "Results below this threshold are dropped. "
                                "Recommended: 0.3–0.5 to filter low-relevance noise.")
     p_search.add_argument("--combined", action="store_true",
                           help="Combined search: long-term + recent short-term memories")
-    p_search.add_argument("--recent-days", type=int, default=7,
-                          help="Number of recent days to include in combined search (default: 7)")
+    p_search.add_argument("--recent-days", type=int, default=3,
+                          help="Number of recent days to include in combined search (default: 3)")
     p_search.set_defaults(func=search_memory)
 
     # list

--- a/server.py
+++ b/server.py
@@ -156,7 +156,7 @@ class SearchMemoryRequest(BaseModel):
     user_id: str = Field(..., description="User identifier")
     agent_id: Optional[str] = Field(None, description="Filter by agent")
     run_id: Optional[str] = Field(None, description="Filter by run")
-    top_k: int = Field(10, description="Max results to return", ge=1, le=100)
+    top_k: int = Field(5, description="Max results to return", ge=1, le=100)
     min_score: float = Field(0.0, description="Minimum relevance score (0.0–1.0); results below this are dropped", ge=0.0, le=1.0)
 
 
@@ -165,8 +165,8 @@ class CombinedSearchRequest(BaseModel):
     query: str = Field(..., description="Natural language query")
     user_id: str = Field(..., description="User identifier")
     agent_id: Optional[str] = Field(None, description="Filter by agent")
-    top_k: int = Field(10, description="Max results to return", ge=1, le=100)
-    recent_days: int = Field(7, description="Number of recent days to include in search", ge=1, le=30)
+    top_k: int = Field(5, description="Max results to return", ge=1, le=100)
+    recent_days: int = Field(3, description="Number of recent days to include in search", ge=1, le=30)
     min_score: float = Field(0.0, description="Minimum relevance score (0.0–1.0); results below this are dropped", ge=0.0, le=1.0)
 
 


### PR DESCRIPTION
## Changes

### server.py + cli.py
- Add `min_score` parameter (float 0.0–1.0, default 0.0) to both `/memory/search` and `/memory/search_combined`
- Results below threshold are filtered before returning
- Reduce default `top_k`: 10 → 5 (fewer tokens in agent context)
- Reduce default `recent_days`: 7 → 3 (most queries only need recent context; callers can override)
- CLI: `--min-score` and `--top-k` flags updated accordingly

### SKILL.md (mem0-memory skill)
- Retrieval redesigned from 'always search' ritual to a 3-step decision framework
- Step 1: decide if retrieval is actually needed (skip for code/git/shell tasks)
- Step 2: extract precise query keywords, not vague phrases
- Step 3: evaluate score after retrieval before injecting into context
- Mandatory scenario table now includes `--recent-days` guidance per scenario type
- `--min-score 0.3` recommended for specific queries
- Weekly/daily time range mapped to explicit `--recent-days` values