### PR TITLE
fix: add update-services.sh to sync systemd service files after restructure

### DIFF
--- a/tools/update-services.sh
+++ b/tools/update-services.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# update-services.sh
+# Sync systemd user service/timer files from repo to ~/.config/systemd/user/
+# Run this after any git pull that changes files under systemd/
+#
+# Usage:
+#   bash tools/update-services.sh
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+SYSTEMD_SRC="$REPO_ROOT/systemd"
+SYSTEMD_DST="$HOME/.config/systemd/user"
+
+echo "=== mem0 service file sync ==="
+echo "Source: $SYSTEMD_SRC"
+echo "Dest:   $SYSTEMD_DST"
+echo ""
+
+mkdir -p "$SYSTEMD_DST"
+
+# Files to sync (user-level services/timers only)
+USER_UNITS=(
+  "mem0-snapshot.service"
+  "mem0-snapshot.timer"
+  "mem0-auto-digest.service"
+  "mem0-auto-digest.timer"
+  "mem0-dream.service"
+  "mem0-dream.timer"
+)
+
+updated=0
+for unit in "${USER_UNITS[@]}"; do
+  src="$SYSTEMD_SRC/$unit"
+  dst="$SYSTEMD_DST/$unit"
+
+  if [ ! -f "$src" ]; then
+    echo "  SKIP  $unit (not found in repo)"
+    continue
+  fi
+
+  if [ -f "$dst" ] && diff -q "$src" "$dst" > /dev/null 2>&1; then
+    echo "  OK    $unit (up to date)"
+  else
+    cp "$src" "$dst"
+    echo "  UPDATED $unit"
+    updated=$((updated + 1))
+  fi
+done
+
+if [ "$updated" -gt 0 ]; then
+  echo ""
+  echo "Reloading systemd user daemon..."
+  systemctl --user daemon-reload
+  echo "Done. $updated file(s) updated."
+  echo ""
+  echo "Active timers:"
+  systemctl --user list-timers --no-pager 2>/dev/null | grep mem0 || true
+else
+  echo ""
+  echo "All service files are up to date."
+fi


### PR DESCRIPTION
## 问题

PR #21（项目结构重组）将 `session_snapshot.py` 从根目录移到 `pipelines/` 子目录，但 EC2 实例上 `~/.config/systemd/user/mem0-snapshot.service` 中的路径**没有同步更新**。

导致 session_snapshot 每 5 分钟执行一次全部报错：
```
can't open file '/home/ec2-user/workspace/mem0-memory-service/session_snapshot.py': [Errno 2] No such file or directory
```

**影响时间**：约 2026-03-31 ~ 2026-04-03，整整 3 天记忆管道完全停摆：
- 无日记写入 → 无短期记忆 → 无长期记忆
- 所有 agent (dev/blog/pm/pjm/prototype) 期间的对话内容**全部丢失**

## 修复

新增 `tools/update-services.sh`：
- 将 `systemd/` 目录下的所有 user-level service/timer 文件同步到 `~/.config/systemd/user/`
- 自动执行 `systemctl --user daemon-reload`
- 显示哪些文件被更新

## 预防规则

**任何涉及 pipeline 脚本移动/重命名的 PR，合并后必须在目标实例上运行：**
```bash
bash tools/update-services.sh
```