### PR TITLE
docs: update how-it-works for Docker-first deployment (EN+ZH)

### DIFF
--- a/docs/guide/how-it-works.md
+++ b/docs/guide/how-it-works.md
@@ -111,9 +111,21 @@ On every heartbeat tick, the agent performs memory maintenance in order:
              (infer=True)          (infer=True) + delete
 ```
 
-## Daily Automation Timeline
+## Deployment: Docker vs. systemd
 
-All automation runs as systemd user timers:
+The memory pipeline scripts (`session_snapshot`, `auto_digest`, `auto_dream`, `memory_sync`) run identically regardless of deployment method. Only the process manager differs:
+
+| | Docker (recommended) | systemd |
+|---|---|---|
+| **API server** | `mem0-api` container | systemd service |
+| **Pipeline runner** | `mem0-pipeline` container (cron) | systemd user timers |
+| **Diary file access** | via bind mount `~/.openclaw → /openclaw` | direct filesystem |
+| **Patch management** | automatic at build time | manual `python3 tools/patch_s3vectors_filter.py` |
+| **Restart on crash** | `restart: unless-stopped` | systemd `Restart=on-failure` |
+
+For deployment details, see [Docker Setup](../deploy/docker) or [systemd Setup](../deploy/systemd).
+
+## Daily Automation Timeline
 
 | Time (UTC) | Script | What it does |
 |-----------|--------|--------------|
@@ -121,6 +133,8 @@ All automation runs as systemd user timers:
 | Every 15 min | `pipelines/auto_digest.py --today` | Incremental: read new diary content → mem0 short-term (infer=True, mem0 handles dedup) |
 | 01:00 | `pipelines/memory_sync.py` | Sync `MEMORY.md` → mem0 long-term (hash dedup) |
 | 02:00 | `pipelines/auto_dream.py` | **AutoDream**: Step 1: yesterday diary → mem0 long-term (infer=True); Step 2: 7-day-old short-term → re-add to long-term (infer=True) then delete |
+
+> In Docker deployments, these scripts run as cron jobs inside the `mem0-pipeline` container. In systemd deployments, they run as user timers. The schedule and behavior are identical regardless of deployment method.
 
 ## auto_digest Mode
 

--- a/docs/zh/guide/how-it-works.md
+++ b/docs/zh/guide/how-it-works.md
@@ -110,9 +110,21 @@ Agent 读到「🔴 Agent Memory Behavior」规则
              (infer=True)          (infer=True) + 删除
 ```
 
-## 每日自动化时序
+## 部署方式：Docker vs. systemd
 
-所有自动化任务以 systemd user timer 方式运行：
+记忆管线脚本（`session_snapshot`、`auto_digest`、`auto_dream`、`memory_sync`）无论哪种部署方式都以相同逻辑运行，区别仅在于进程管理器：
+
+| | Docker（推荐） | systemd |
+|---|---|---|
+| **API 服务** | `mem0-api` 容器 | systemd service |
+| **管线执行** | `mem0-pipeline` 容器（cron） | systemd user timers |
+| **日记文件访问** | 通过 bind mount `~/.openclaw → /openclaw` | 直接文件系统 |
+| **补丁管理** | 构建时自动应用 | 手动 `python3 tools/patch_s3vectors_filter.py` |
+| **崩溃重启** | `restart: unless-stopped` | systemd `Restart=on-failure` |
+
+部署详情参见 [Docker 部署](../deploy/docker) 或 [systemd 部署](../deploy/systemd)。
+
+## 每日自动化时序
 
 | 时间（UTC） | 脚本 | 做什么 |
 |------------|------|--------|
@@ -120,6 +132,8 @@ Agent 读到「🔴 Agent Memory Behavior」规则
 | 每 15 分钟 | `pipelines/auto_digest.py --today` | 增量模式：读取日记新增内容 → mem0 短期记忆（infer=True，mem0 自动去重） |
 | 01:00 | `pipelines/memory_sync.py` | 同步 `MEMORY.md` → mem0 长期记忆（hash 去重） |
 | 02:00 | `pipelines/auto_dream.py` | **AutoDream**：Step1: 昨日日记 → mem0 长期记忆（infer=True）；Step2: 7天前短期记忆 → re-add 到长期（infer=True）后删除 |
+
+> Docker 部署中，这些脚本以 cron 任务的形式在 `mem0-pipeline` 容器内运行；systemd 部署中，以用户 timer 形式运行。两种方式的调度时间和行为完全一致。
 
 ## auto_digest 模式
 


### PR DESCRIPTION
## Changes

Update `how-it-works.md` (English + Chinese) to reflect the Docker-first deployment introduced in #37.

### What changed

**1. Daily Automation Timeline**
- Clarified that pipeline scripts run as cron jobs inside `mem0-pipeline` container (Docker) or as systemd user timers
- Added note: schedule and behavior are identical regardless of deployment method

**2. New section: Deployment: Docker vs. systemd**
- 5-row comparison table (API server / pipeline runner / diary file access / patch management / restart policy)
- Links to Docker Setup and systemd Setup deploy docs

**3. systemd-as-default language fixed**
- Remaining paragraphs that implied systemd as the only deployment method updated to be deployment-neutral