### PR TITLE
fix: rename duplicate Quick Start in docker deploy docs

### DIFF
--- a/docs/deploy/docker.md
+++ b/docs/deploy/docker.md
@@ -112,7 +112,7 @@ python3 tools/migrate_s3vectors_to_pgvector.py migrate \
   --user-ids boss
 ```
 
-## Quick Start
+## 🐳 Quick Start: Docker with Managed Vector Store (S3 Vectors / OpenSearch)
 
 ```bash
 # 1. Clone the repo

--- a/docs/zh/deploy/docker.md
+++ b/docs/zh/deploy/docker.md
@@ -112,7 +112,7 @@ python3 tools/migrate_s3vectors_to_pgvector.py migrate \
   --user-ids boss
 ```
 
-## 快速开始
+## 🐳 快速开始：Docker + 托管向量数据库（S3 Vectors / OpenSearch）
 
 ```bash
 # 1. 克隆仓库


### PR DESCRIPTION
Two sections both named 'Quick Start' in docker.md caused confusion. Rename the second one to make the distinction clear.