### PR TITLE
docs: clarify Quick Trial vs Production Deployment labels in docker deploy docs

### DIFF
--- a/docs/deploy/docker.md
+++ b/docs/deploy/docker.md
@@ -42,7 +42,7 @@ The AWS identity used (IAM Role or Access Key) must have the following permissio
 
 **Outside EC2**: Set `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` in `.env`.
 
-## 🚀 Quickest Start: Local pgvector (No Cloud Required)
+## 🚀 Quick Trial: Local pgvector (Demo / Local Dev, No Cloud Required)
 
 If you just want to try mem0 Memory Service locally without setting up S3 Vectors or OpenSearch, use the built-in PostgreSQL + pgvector backend. No AWS vector store credentials needed — only AWS Bedrock (LLM + Embedding) is required.
 
@@ -112,7 +112,7 @@ python3 tools/migrate_s3vectors_to_pgvector.py migrate \
   --user-ids boss
 ```
 
-## 🐳 Quick Start: Docker with Managed Vector Store (S3 Vectors / OpenSearch)
+## 🐳 Production Deployment: Docker with Managed Vector Store (S3 Vectors / OpenSearch)
 
 ```bash
 # 1. Clone the repo

--- a/docs/zh/deploy/docker.md
+++ b/docs/zh/deploy/docker.md
@@ -42,7 +42,7 @@
 
 **非 EC2 环境**：在 `.env` 中设置 `AWS_ACCESS_KEY_ID` 和 `AWS_SECRET_ACCESS_KEY`。
 
-## 🚀 最快启动：本地 pgvector（无需云服务）
+## 🚀 快速体验：本地 pgvector（Demo / 本地开发，无需云服务）
 
 如果只想在本地快速体验 mem0 Memory Service，无需配置 S3 Vectors 或 OpenSearch，可以使用内置的 PostgreSQL + pgvector 后端。只需要 AWS Bedrock（LLM + Embedding）凭证即可。
 
@@ -112,7 +112,7 @@ python3 tools/migrate_s3vectors_to_pgvector.py migrate \
   --user-ids boss
 ```
 
-## 🐳 快速开始：Docker + 托管向量数据库（S3 Vectors / OpenSearch）
+## 🐳 生产环境部署：Docker + 托管向量数据库（S3 Vectors / OpenSearch）
 
 ```bash
 # 1. 克隆仓库


### PR DESCRIPTION
Rename section headers to make the intent crystal clear:

| Before | After |
|--------|-------|
| 🚀 Quickest Start: Local pgvector | 🚀 **Quick Trial**: Local pgvector (Demo / Local Dev) |
| 🐳 Quick Start: Docker with Managed Vector Store | 🐳 **Production Deployment**: Docker with Managed Vector Store |

Same changes in ZH: 快速体验 vs 生产环境部署