### PR TITLE
feat: one-line deploy — smart install.sh + onboarding docs

### DIFF
--- a/docs/deploy/docker.md
+++ b/docs/deploy/docker.md
@@ -44,6 +44,8 @@ The AWS identity used (IAM Role or Access Key) must have the following permissio
 
 ## 🚀 Quick Trial: Local pgvector (Demo / Local Dev, No Cloud Required)
 
+> **Quickest path**: Run `./install.sh` — auto-detects your AWS Region and sets up everything with defaults. See [One-Line Deploy](../guide/getting-started#one-line-deploy).
+
 If you just want to try mem0 Memory Service locally without setting up S3 Vectors or OpenSearch, use the built-in PostgreSQL + pgvector backend. No AWS vector store credentials needed — only AWS Bedrock (LLM + Embedding) is required.
 
 ```bash

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -54,6 +54,27 @@ OpenClaw Agents (agent1, agent2, ...)
   - If using S3Vectors: `s3vectors:*` on the bucket resource
   - EC2 users: attach an IAM Role to the instance — no Access Key needed
 
+## One-Line Deploy
+
+The fastest way to get started — send this to your OpenClaw AI assistant:
+
+---
+
+> Deploy **mem0 Memory Service** for me using local pgvector.
+>
+> Steps:
+> 1. `git clone https://github.com/norrishuang/mem0-memory-service.git && cd mem0-memory-service`
+> 2. Run `./install.sh` — it will auto-detect your AWS Region and use local pgvector (no cloud vector store needed)
+> 3. Verify: `curl http://localhost:8230/health`
+> 4. Enable the skill in OpenClaw Settings → Skills → mem0-memory
+
+---
+
+That's it. The installer handles everything: AWS Region detection, default config, Docker containers, and skill installation.
+
+> **Prerequisites**: Docker 20.10+, AWS Bedrock access (IAM Role on EC2 or configured credentials).
+> No OpenSearch or S3 Vectors account needed to get started.
+
 ## Deployment
 
 Choose the deployment method that fits your setup:

--- a/docs/zh/deploy/docker.md
+++ b/docs/zh/deploy/docker.md
@@ -44,6 +44,8 @@
 
 ## 🚀 快速体验：本地 pgvector（Demo / 本地开发，无需云服务）
 
+> **最快方式**：直接运行 `./install.sh`，自动探测 AWS Region，默认配置一键完成。参见[一键部署](../guide/getting-started#一键部署)。
+
 如果只想在本地快速体验 mem0 Memory Service，无需配置 S3 Vectors 或 OpenSearch，可以使用内置的 PostgreSQL + pgvector 后端。只需要 AWS Bedrock（LLM + Embedding）凭证即可。
 
 ```bash

--- a/docs/zh/guide/getting-started.md
+++ b/docs/zh/guide/getting-started.md
@@ -52,6 +52,27 @@ OpenClaw Agents (agent1, agent2, ...)
   - 如果使用 S3Vectors：`s3vectors:*`（对应 bucket 资源）
   - EC2 用户：将 IAM Role 附加到实例即可，无需在 .env 中配置 Access Key
 
+## 一键部署
+
+最快的体验方式 — 把下面这段话发给你的 OpenClaw AI 助手：
+
+---
+
+> 帮我部署 **mem0 Memory Service**，使用本地 pgvector 模式。
+>
+> 步骤：
+> 1. `git clone https://github.com/norrishuang/mem0-memory-service.git && cd mem0-memory-service`
+> 2. 运行 `./install.sh` — 自动检测 AWS Region，使用本地 pgvector（无需云端向量数据库）
+> 3. 验证：`curl http://localhost:8230/health`
+> 4. 在 OpenClaw 设置 → Skills → 启用 mem0-memory
+
+---
+
+安装脚本自动处理：AWS Region 探测、默认配置、Docker 容器启动、Skill 安装，无需手动配置任何内容。
+
+> **前提条件**：Docker 20.10+，AWS Bedrock 访问权限（EC2 IAM Role 或已配置凭证）。
+> 开始体验无需 OpenSearch 或 S3 Vectors。
+
 ## 部署方式
 
 根据你的环境选择合适的部署方式：

--- a/install.sh
+++ b/install.sh
@@ -1,21 +1,20 @@
 #!/usr/bin/env bash
 #
-# mem0 Memory Service - Docker installer for OpenClaw
+# mem0 Memory Service - One-Line Docker Installer for OpenClaw
 #
 # Usage:
 #   ./install.sh
 #
 # Prerequisites:
-#   - Docker 20.10+
-#   - docker compose (v2)
-#   - AWS credentials configured (IAM Role on EC2, or Access Key)
+#   - Docker 20.10+ with docker compose (v2)
+#   - AWS Bedrock access (IAM Role on EC2, or configured credentials)
 #
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-echo "🧠 mem0 Memory Service Installer (Docker)"
-echo "============================================"
+echo "🧠 mem0 Memory Service Installer"
+echo "=================================="
 
 # ─── 0. Check Docker ───
 echo ""
@@ -36,120 +35,76 @@ fi
 echo "   ✅ Docker $(docker --version | grep -oP '\d+\.\d+\.\d+')"
 echo "   ✅ $(docker compose version)"
 
-# ─── 1. Collect config ───
+# ─── 1. Auto-detect AWS Region ───
 echo ""
-echo "📋 Configuration (press Enter for defaults):"
-echo ""
+echo "🌍 Detecting AWS Region..."
 
-# Vector store choice
-echo "Vector store backend:"
-echo "  1) opensearch (default)"
-echo "  2) s3vectors (AWS S3 Vectors — lower cost, pay-per-use)"
-read -rp "Choose [1]: " VS_CHOICE
-case "${VS_CHOICE}" in
-    2) VECTOR_STORE="s3vectors" ;;
-    *) VECTOR_STORE="opensearch" ;;
-esac
-
-read -rp "AWS region [us-east-1]: " AWS_REG
-AWS_REG=${AWS_REG:-us-east-1}
-
-# Vector store specific config
-if [ "$VECTOR_STORE" = "opensearch" ]; then
-    read -rp "OpenSearch host: " OS_HOST
-    if [ -z "$OS_HOST" ]; then
-        echo "❌ OpenSearch host is required."
-        exit 1
-    fi
-    read -rp "OpenSearch port [443]: " OS_PORT
-    OS_PORT=${OS_PORT:-443}
-    read -rp "OpenSearch username [admin]: " OS_USER
-    OS_USER=${OS_USER:-admin}
-    read -rsp "OpenSearch password: " OS_PASS
-    echo ""
-    if [ -z "$OS_PASS" ]; then
-        echo "❌ OpenSearch password is required."
-        exit 1
-    fi
-    read -rp "Use SSL? [true]: " OS_SSL
-    OS_SSL=${OS_SSL:-true}
-    read -rp "Index/collection name [mem0_memories]: " COLLECTION
-    COLLECTION=${COLLECTION:-mem0_memories}
+AWS_REG=""
+if [ -n "${AWS_REGION:-}" ]; then
+    AWS_REG="$AWS_REGION"
+    echo "   ✅ From \$AWS_REGION: ${AWS_REG}"
+elif command -v aws &>/dev/null && AWS_CLI_REG=$(aws configure get region 2>/dev/null) && [ -n "$AWS_CLI_REG" ]; then
+    AWS_REG="$AWS_CLI_REG"
+    echo "   ✅ From aws configure: ${AWS_REG}"
+elif [ -n "${AWS_DEFAULT_REGION:-}" ]; then
+    AWS_REG="$AWS_DEFAULT_REGION"
+    echo "   ✅ From \$AWS_DEFAULT_REGION: ${AWS_REG}"
 else
-    read -rp "S3Vectors bucket name: " S3V_BUCKET
-    if [ -z "$S3V_BUCKET" ]; then
-        echo "❌ S3Vectors bucket name is required."
-        exit 1
-    fi
-    read -rp "S3Vectors index name [mem0]: " S3V_INDEX
-    S3V_INDEX=${S3V_INDEX:-mem0}
+    AWS_REG="us-east-1"
+    echo "   ℹ️  No region detected, using default: ${AWS_REG}"
 fi
 
-read -rp "OpenClaw data directory [~/.openclaw]: " OPENCLAW_BASE
+# ─── 2. One question: OpenClaw directory ───
+echo ""
+read -rp "📂 OpenClaw data directory [~/.openclaw]: " OPENCLAW_BASE
 OPENCLAW_BASE=${OPENCLAW_BASE:-~/.openclaw}
 
-read -rp "Embedding model [amazon.titan-embed-text-v2:0]: " EMB_MODEL
-EMB_MODEL=${EMB_MODEL:-amazon.titan-embed-text-v2:0}
-
-read -rp "LLM model [us.anthropic.claude-haiku-4-5-20251001-v1:0]: " LLM_MODEL
-LLM_MODEL=${LLM_MODEL:-us.anthropic.claude-haiku-4-5-20251001-v1:0}
-
-read -rp "Service port [8230]: " SVC_PORT
-SVC_PORT=${SVC_PORT:-8230}
-
-# ─── 2. Write .env file ───
+# ─── 3. Write .env ───
 echo ""
 echo "📝 Writing .env..."
 ENV_FILE="${SCRIPT_DIR}/.env"
 
 cat > "$ENV_FILE" <<EOF
+# Auto-detected or default
 AWS_REGION=${AWS_REG}
-VECTOR_STORE=${VECTOR_STORE}
-EOF
 
-if [ "$VECTOR_STORE" = "opensearch" ]; then
-    cat >> "$ENV_FILE" <<EOF
-OPENSEARCH_HOST=${OS_HOST}
-OPENSEARCH_PORT=${OS_PORT}
-OPENSEARCH_USER=${OS_USER}
-OPENSEARCH_PASSWORD=${OS_PASS}
-OPENSEARCH_USE_SSL=${OS_SSL}
-OPENSEARCH_VERIFY_CERTS=true
-OPENSEARCH_COLLECTION=${COLLECTION}
-EOF
-else
-    cat >> "$ENV_FILE" <<EOF
-S3VECTORS_BUCKET_NAME=${S3V_BUCKET}
-S3VECTORS_INDEX_NAME=${S3V_INDEX}
-EOF
-fi
+# pgvector (local, no cloud vector store needed)
+VECTOR_STORE=pgvector
+PGVECTOR_HOST=mem0-postgres
+PGVECTOR_DB=mem0
+PGVECTOR_USER=mem0
+PGVECTOR_PASSWORD=mem0-local
 
-cat >> "$ENV_FILE" <<EOF
-EMBEDDING_MODEL=${EMB_MODEL}
+# Models (Bedrock)
+EMBEDDING_MODEL=amazon.titan-embed-text-v2:0
 EMBEDDING_DIMS=1024
-LLM_MODEL=${LLM_MODEL}
+LLM_MODEL=us.anthropic.claude-haiku-4-5-20251001-v1:0
+
+# Service
 SERVICE_HOST=0.0.0.0
-SERVICE_PORT=${SVC_PORT}
+SERVICE_PORT=8230
+
+# OpenClaw
 OPENCLAW_BASE=${OPENCLAW_BASE}
 EOF
 
 chmod 600 "$ENV_FILE"
 echo "   ✅ Config written to ${ENV_FILE}"
 
-# ─── 3. Start Docker containers ───
+# ─── 4. Start Docker containers ───
 echo ""
-echo "🐳 Starting Docker containers..."
+echo "🐳 Starting Docker containers (pgvector mode)..."
 cd "$SCRIPT_DIR"
-docker compose up -d --build
+docker compose --profile pgvector up -d --build
 
-# ─── 4. Wait for health check ───
+# ─── 5. Wait for health check ───
 echo ""
 echo "🧪 Waiting for service to be healthy..."
-MAX_WAIT=60
+MAX_WAIT=90
 WAITED=0
 while [ $WAITED -lt $MAX_WAIT ]; do
-    if curl -s "http://127.0.0.1:${SVC_PORT}/health" 2>/dev/null | grep -q '"ok"'; then
-        echo "   ✅ API healthy at http://127.0.0.1:${SVC_PORT}"
+    if curl -s "http://127.0.0.1:8230/health" 2>/dev/null | grep -q '"ok"'; then
+        echo "   ✅ API healthy at http://127.0.0.1:8230"
         break
     fi
     sleep 3
@@ -163,7 +118,7 @@ if [ $WAITED -ge $MAX_WAIT ]; then
     exit 1
 fi
 
-# ─── 5. Install OpenClaw Skill ───
+# ─── 6. Install OpenClaw Skill ───
 echo ""
 SKILL_DIR="${HOME}/.openclaw/skills/mem0-memory"
 echo "📝 Installing OpenClaw Skill to ${SKILL_DIR}..."
@@ -183,7 +138,7 @@ echo "════════════════════════�
 echo "🎉 mem0 Memory Service installed!"
 echo ""
 echo "  Containers: docker compose ps"
-echo "  API:        http://127.0.0.1:${SVC_PORT}"
+echo "  API:        http://127.0.0.1:8230"
 echo "  Logs:       docker compose logs -f"
 echo "  Stop:       docker compose down"
 echo "  Skill:      ${SKILL_DIR}/SKILL.md"
@@ -193,6 +148,5 @@ echo "    docker compose exec mem0-api python3 cli.py add --user me --agent dev 
 echo "    docker compose exec mem0-api python3 cli.py search --user me --agent dev --query 'hello'"
 echo ""
 echo "  💡 EC2 users: Use IAM Role — no Access Key needed in .env"
+echo "  💡 Want to switch to S3 Vectors or OpenSearch? See docs/deploy/docker.md"
 echo "════════════════════════════════════════"
-
-# If you prefer systemd deployment, see docs/deploy/systemd.md


### PR DESCRIPTION
## Goal
Lower the barrier for new users. Target: OpenClaw + AWS users can deploy with a single message to their AI assistant.

## Changes

### `install.sh` (major simplification)
| Before | After |
|--------|-------|
| 6+ interactive questions | **1 question** (OpenClaw dir, Enter = default) |
| User must choose vector store | **Default pgvector** (local, no cloud needed) |
| User must enter AWS Region | **Auto-detected** (env → aws cli → us-east-1) |

### Docs
- `getting-started.md`: new **## One-Line Deploy** section — user sends one prompt to OpenClaw, done
- `docs/zh/`: Chinese version **## 一键部署**
- `deploy/docker.md`: Quick Trial section now links back to one-line deploy

## User experience
```
User: 帮我部署 mem0 Memory Service
AI:   git clone ... && cd mem0-memory-service && ./install.sh
      (press Enter once for OpenClaw dir)
Done. ~2 minutes total.
```