### PR TITLE
feat: cli list pagination support (#49)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -121,7 +121,7 @@ def search_memory(args):
 
 
 def list_memories(args):
-    params = {"user_id": args.user}
+    params = {"user_id": args.user, "limit": args.limit, "offset": args.offset}
     if args.agent:
         params["agent_id"] = args.agent
     if args.run:
@@ -129,7 +129,19 @@ def list_memories(args):
 
     resp = requests.get(f"{BASE_URL}/memory/list", params=params, timeout=30)
     resp.raise_for_status()
-    print(json.dumps(resp.json(), indent=2, ensure_ascii=False))
+    data = resp.json()
+
+    if args.count_only:
+        agent_label = args.agent or "all"
+        print(f"{agent_label} 共 {data.get('total', '?')} 条记忆")
+        return
+
+    print(json.dumps(data, indent=2, ensure_ascii=False))
+
+    results = data.get("results", [])
+    if len(results) == args.limit:
+        next_offset = args.offset + args.limit
+        print(f"\n# 提示：已达返回上限({args.limit}条)，使用 --offset {next_offset} 查看更多")
 
 
 def get_memory(args):
@@ -187,6 +199,9 @@ def main():
     p_list.add_argument("--user", required=True)
     p_list.add_argument("--agent", default=None)
     p_list.add_argument("--run", default=None)
+    p_list.add_argument("--limit", type=int, default=100, help="Max results to return (default: 100)")
+    p_list.add_argument("--offset", type=int, default=0, help="Skip first N results (default: 0)")
+    p_list.add_argument("--count-only", action="store_true", help="Only print total count")
     p_list.set_defaults(func=list_memories)
 
     # get

--- a/server.py
+++ b/server.py
@@ -356,6 +356,7 @@ async def list_memories(
     agent_id: Optional[str] = None,
     run_id: Optional[str] = None,
     limit: int = 100,
+    offset: int = 0,
 ):
     """List all memories for a user, optionally filtered by agent/run."""
     kwargs = {"user_id": user_id}
@@ -367,8 +368,15 @@ async def list_memories(
     try:
         loop = asyncio.get_event_loop()
         kw = dict(kwargs)
-        results = await loop.run_in_executor(_mem0_executor, lambda: memory.get_all(**kw))
-        return {"status": "ok", "results": results}
+        all_results = await loop.run_in_executor(_mem0_executor, lambda: memory.get_all(**kw))
+        # Normalize: get_all may return dict with "results" key or a list
+        if isinstance(all_results, dict) and "results" in all_results:
+            items = all_results["results"]
+        else:
+            items = all_results if isinstance(all_results, list) else []
+        total = len(items)
+        results = items[offset:offset + limit]
+        return {"status": "ok", "results": results, "total": total}
     except Exception as e:
         logger.error(f"Error listing memories: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=str(e))


### PR DESCRIPTION
## Changes

Closes #49

### server.py
- Added `offset` query parameter (default 0) to `/memory/list`
- Response now includes `total` field (total memory count before pagination)
- Normalizes `get_all()` return value (handles both dict and list formats)

### cli.py
- Added `--limit INT` (default 100) — max results to return
- Added `--offset INT` (default 0) — skip first N results
- Added `--count-only` — only prints total count (`<agent> 共 N 条记忆`)
- When results hit the limit, prints hint: `# 提示：已达返回上限(N条)，使用 --offset N 查看更多`

### Testing
- `python3 cli.py list --user boss --agent dev --limit 5` → returns 5 results ✅
- `python3 cli.py list --user boss --agent dev --count-only` → prints total only ✅
- `python3 cli.py list --user boss --agent dev --limit 5 --offset 5` → returns next 5 ✅