### PR TITLE
feat: auto_digest run summary stats (#52)

### DIFF
--- a/pipelines/auto_digest.py
+++ b/pipelines/auto_digest.py
@@ -213,20 +213,22 @@ def write_to_mem0(event: str, run_id: str, agent_id: str, incremental: bool = Fa
 
 
 def process_agent(agent_id: str, workspace: Path, date: str, incremental: bool = False,
-                  offsets: dict | None = None):
+                  offsets: dict | None = None) -> dict:
     """处理单个 agent 的日记
 
     incremental=False: 读取整个日记文件，LLM 提炼后写 mem0（昨日全量模式）
     incremental=True:  从 offset 开始分批读取（每批 50KB），逐批 POST 给 mem0，
                        批次间 sleep 避免打爆服务。处理完更新 offset，下次只读新增。
     Batches are aligned to '## ' section boundaries to avoid cutting context mid-paragraph.
+
+    Returns a stats dict: {status, new_bytes, memories_added, batches_sent}
     """
     import time
 
     diary_file = workspace / "memory" / f"{date}.md"
     if not diary_file.exists():
         logger.debug(f"[{agent_id}] No diary for {date}")
-        return
+        return {"status": "no_diary", "new_bytes": 0, "memories_added": 0, "batches_sent": 0}
 
     file_size = diary_file.stat().st_size
 
@@ -237,16 +239,18 @@ def process_agent(agent_id: str, workspace: Path, date: str, incremental: bool =
         total_new = file_size - prev_offset
         if total_new <= 0:
             logger.debug(f"[{agent_id}] No new content (offset={prev_offset})")
-            return
+            return {"status": "skipped", "new_bytes": 0, "memories_added": 0, "batches_sent": 0}
 
         if total_new < MIN_CONTENT_BYTES:
             logger.info(f"[{agent_id}] New content too small ({total_new} bytes < {MIN_CONTENT_BYTES}), skipping")
-            return
+            return {"status": "too_small", "new_bytes": total_new, "memories_added": 0, "batches_sent": 0}
 
         logger.info(f"[{agent_id}] Incremental: {total_new} new bytes to process in batches of {BATCH_SIZE_BYTES}B")
 
         current_offset = prev_offset
         batch_num = 0
+        batches_sent = 0
+        batches_failed = 0
         total_batches = (total_new + BATCH_SIZE_BYTES - 1) // BATCH_SIZE_BYTES
 
         with open(diary_file, 'rb') as f:
@@ -274,11 +278,13 @@ def process_agent(agent_id: str, workspace: Path, date: str, incremental: bool =
                 if batch_content.strip():
                     ok = write_to_mem0(batch_content, date, agent_id, incremental=True)
                     if ok:
+                        batches_sent += 1
                         # 每批成功后立即更新 offset，下次可从断点续传
                         current_offset = next_offset
                         agent_offsets[date] = current_offset
                         save_offsets(offsets)
                     else:
+                        batches_failed += 1
                         logger.warning(f"[{agent_id}] Batch {batch_num} failed, stopping to retry next run")
                         break
                 else:
@@ -289,6 +295,8 @@ def process_agent(agent_id: str, workspace: Path, date: str, incremental: bool =
                     time.sleep(BATCH_SLEEP_SECS)
 
         logger.info(f"[{agent_id}] Done: processed up to offset {agent_offsets.get(date, prev_offset)}/{file_size}")
+        status = "failed" if batches_failed > 0 and batches_sent == 0 else "ok"
+        return {"status": status, "new_bytes": total_new, "memories_added": 0, "batches_sent": batches_sent}
 
     else:
         # 全量模式：读取整个文件，LLM 提炼后写 mem0
@@ -297,17 +305,45 @@ def process_agent(agent_id: str, workspace: Path, date: str, incremental: bool =
 
         if not content.strip():
             logger.info(f"[{agent_id}] Content is empty, skipping")
-            return
+            return {"status": "skipped", "new_bytes": 0, "memories_added": 0, "batches_sent": 0}
 
         events = call_llm_extract(content)
         if not events:
-            return
+            return {"status": "skipped", "new_bytes": file_size, "memories_added": 0, "batches_sent": 0}
 
         success = sum(1 for e in events if write_to_mem0(e, date, agent_id, incremental=False))
         logger.info(f"[{agent_id}] Wrote {success}/{len(events)} events to mem0 (run_id={date})")
+        status = "ok" if success > 0 else "failed"
+        return {"status": status, "new_bytes": file_size, "memories_added": success, "batches_sent": 0}
+
+
+def _log_run_summary(results: list[tuple[str, dict]], elapsed: float):
+    """打印本次运行的汇总统计日志"""
+    total_memories = 0
+    agents_processed = 0
+
+    for agent_id, stats in results:
+        s = stats["status"]
+        if s in ("ok", "failed"):
+            agents_processed += 1
+            mem_count = stats["memories_added"] or stats["batches_sent"]
+            total_memories += mem_count
+            extra = f"新内容 {stats['new_bytes']} bytes"
+            if s == "failed":
+                extra += "，mem0 写入失败"
+            logger.info(f"[{agent_id}] 新增 {mem_count} 条记忆（{extra}）")
+        elif s == "no_diary":
+            logger.debug(f"[{agent_id}] 无日记，跳过")
+        else:
+            logger.debug(f"[{agent_id}] 无新内容，跳过")
+
+    logger.info(f"--- 本次合计: 处理 {agents_processed} 个 agent，"
+                f"新增 {total_memories} 条记忆，耗时 {int(elapsed)}s ---")
 
 
 def main():
+    import time as _time
+
     parser = argparse.ArgumentParser(description="auto_digest: extract memories from diary")
     parser.add_argument("--today", action="store_true",
                         help="Incremental mode: process today's diary (run every 15 min)")
@@ -318,6 +354,9 @@ def main():
     workspaces = load_agent_workspaces()
     logger.info(f"Discovered {len(workspaces)} agents: {list(workspaces.keys())}")
 
+    t0 = _time.monotonic()
+    results: list[tuple[str, dict]] = []
+
     if args.today:
         # 今日增量模式
         today = get_beijing_today()
@@ -326,9 +365,11 @@ def main():
 
         for agent_id, workspace in sorted(workspaces.items()):
             try:
-                process_agent(agent_id, workspace, today, incremental=True, offsets=offsets)
+                stats = process_agent(agent_id, workspace, today, incremental=True, offsets=offsets)
             except Exception as e:
                 logger.error(f"[{agent_id}] Error: {e}", exc_info=True)
+                stats = {"status": "failed", "new_bytes": 0, "memories_added": 0, "batches_sent": 0}
+            results.append((agent_id, stats))
 
         save_offsets(offsets)
         logger.info("Incremental digest completed")
@@ -339,12 +380,15 @@ def main():
 
         for agent_id, workspace in sorted(workspaces.items()):
             try:
-                process_agent(agent_id, workspace, yesterday, incremental=False)
+                stats = process_agent(agent_id, workspace, yesterday, incremental=False)
             except Exception as e:
                 logger.error(f"[{agent_id}] Error: {e}", exc_info=True)
+                stats = {"status": "failed", "new_bytes": 0, "memories_added": 0, "batches_sent": 0}
+            results.append((agent_id, stats))
 
         logger.info("Full digest completed")
 
+    _log_run_summary(results, _time.monotonic() - t0)
     logger.info("=" * 80)
 
 


### PR DESCRIPTION
## Issue #52: auto_digest 增加写入统计日志

### 改动

- `process_agent()` 所有 return 路径改为返回 stats dict: `{status, new_bytes, memories_added, batches_sent}`
- 新增 `_log_run_summary()` 函数，在 `main()` 结束时打印汇总
- `main()` 收集每个 agent 的返回值，计时，循环结束后输出摘要

### 日志输出示例

```
[dev] 新增 12 条记忆（新内容 8192 bytes）
[main] 无新内容，跳过
[researcher] 新增 0 条记忆（新内容 1024 bytes，mem0 写入失败）
[pjm] 无日记，跳过
--- 本次合计: 处理 2 个 agent，新增 12 条记忆，耗时 28s ---
```

### 注意
- 不破坏现有日志行（只新增）
- exception 路径也返回 failed stats dict，不会丢失统计