### PR TITLE
fix: auto_digest log dedup + main agent workspace mount (#60 #61)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,6 +49,7 @@ services:
     entrypoint: ["/app/docker/entrypoint-pipeline.sh"]
     volumes:
       - ${OPENCLAW_BASE:-~/.openclaw}:/openclaw:rw
+      - ${OPENCLAW_BASE:-~/.openclaw}:/home/ec2-user/clawd:rw  # main agent workspace alias (#61)
       - ./data:/app/data
       - ${AWS_CONFIG_DIR:-~/.aws}:/root/.aws:ro
     env_file:

--- a/pipelines/auto_digest.py
+++ b/pipelines/auto_digest.py
@@ -65,8 +65,7 @@ logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s [%(levelname)s] %(message)s",
     handlers=[
-        logging.FileHandler(LOG_FILE, mode='a'),
-        logging.StreamHandler(sys.stdout)
+        logging.StreamHandler(sys.stdout)  # cron >> /app/data/auto_digest.log handles file writing
     ]
 )
 logger = logging.getLogger(__name__)

--- a/pipelines/auto_dream.py
+++ b/pipelines/auto_dream.py
@@ -38,8 +38,7 @@ logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s [%(levelname)s] %(message)s",
     handlers=[
-        logging.FileHandler(LOG_FILE, mode='a'),
-        logging.StreamHandler(sys.stdout)
+        logging.StreamHandler(sys.stdout)  # cron >> /app/data/auto_dream.log handles file writing
     ]
 )
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Changes

### Fix #60 — auto_digest 日志重复
- `pipelines/auto_digest.py`: 去掉 `FileHandler`，只保留 `StreamHandler(stdout)`，由 cron 的 `>>` 负责写文件（与 session_snapshot 保持一致）
- `pipelines/auto_dream.py`: 同上修复

### Fix #61 — main agent workspace 未挂载
- `docker-compose.yml`: pipeline 容器新增挂载 `OPENCLAW_BASE → /home/ec2-user/clawd`
  - main agent workspace 配置为 `/home/ec2-user/clawd`，实际内容和 OPENCLAW_BASE 是同一目录
  - 容器内增加这条别名挂载后，`load_agent_workspaces()` 能正确找到 main 的日记文件