### PR TITLE
docs: update auto_digest infer=False after LLM layer removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,15 +240,15 @@ python3 cli.py search --user me --agent agent1 --query "keywords" \
 
 ### Automatic Short-Term Memory Extraction
 
-The `auto_digest.py` script runs every 15 minutes with `--today` mode, extracting short-term events from today's diary and storing them in mem0 with `infer=True` (mem0 handles deduplication automatically).
+The `auto_digest.py` script runs every 15 minutes with `--today` mode, extracting short-term events from today's diary and storing them in mem0 with `infer=False` (diary text is passed directly without a custom LLM extraction layer).
 
 #### How It Works
 
 1. **Read today's diary**: Reads today's `YYYY-MM-DD.md` from each agent's workspace. Workspace paths are automatically resolved from `openclaw.json`.
-2. **Write to mem0 with infer=True**: Each diary entry is stored via `mem0.add(infer=True)` with `run_id=today's date`. mem0's LLM automatically extracts key facts and handles deduplication.
+2. **Write to mem0 with infer=False**: Each diary entry is stored via `mem0.add(infer=False)` with `run_id=today's date`. Diary text is passed directly to mem0 without a custom LLM extraction layer.
 3. **Metadata**: `category=short_term, source=auto_digest`
 
-> No `.digest_state.json` state file needed. Uses `infer=True` so mem0 handles fact extraction and deduplication natively.
+> No `.digest_state.json` state file needed. Uses `infer=False` so diary text is stored directly without LLM extraction.
 
 #### Configure Scheduled Task (systemd timer)
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -238,15 +238,15 @@ python3 cli.py search --user me --agent agent1 --query "关键词" \
 
 ### 自动短期记忆提取
 
-`auto_digest.py` 脚本每 15 分钟以 `--today` 模式运行，从今天的日记文件中提取短期事件，以 `infer=True` 存入 mem0（mem0 自动处理事实提取和去重）。
+`auto_digest.py` 脚本每 15 分钟以 `--today` 模式运行，从今天的日记文件中提取短期事件，以 `infer=False` 存入 mem0（日记文本直接传入，不经过自定义 LLM 提取层）。
 
 #### 工作原理
 
 1. **读取今日日记**：从各 Agent 的 workspace 读取**今天**的日记（`YYYY-MM-DD.md`）。Agent workspace 路径自动从 `openclaw.json` 解析，无需硬编码路径。
-2. **以 infer=True 写入 mem0**：每条日记内容通过 `mem0.add(infer=True)` 存储，`run_id=今天日期`。mem0 的 LLM 自动提取关键事实并处理去重。
+2. **以 infer=False 写入 mem0**：每条日记内容通过 `mem0.add(infer=False)` 存储，`run_id=今天日期`。日记文本直接传入 mem0，不经过自定义 LLM 提取层。
 3. **元数据**：`category=short_term, source=auto_digest`
 
-> 不再使用 `.digest_state.json` 增量状态文件。使用 `infer=True`，mem0 原生处理事实提取和去重。
+> 不再使用 `.digest_state.json` 增量状态文件。使用 `infer=False`，日记文本直接存储，不经过 LLM 提取。
 
 #### 配置定时任务（systemd timer）
 

--- a/docs/deploy/systemd.md
+++ b/docs/deploy/systemd.md
@@ -28,7 +28,7 @@ systemctl --user enable --now mem0-snapshot.timer
 
 ### Auto Digest (every 15 minutes)
 
-Extracts short-term events from diary files and stores them in mem0 with `infer=True` (`run_id=YYYY-MM-DD`). mem0 automatically handles fact extraction and deduplication.
+Extracts short-term events from diary files and stores them in mem0 with `infer=False` (`run_id=YYYY-MM-DD`). Diary text is passed directly to mem0 without a custom LLM extraction layer.
 
 ```bash
 # Using cron

--- a/docs/guide/architecture.md
+++ b/docs/guide/architecture.md
@@ -67,7 +67,7 @@ flowchart TD
     Diary["memory/YYYY-MM-DD.md\n(diary files)"]
     MemoryMD["MEMORY.md\n(agent curated knowledge)"]
     Snap(["session_snapshot.py\n(every 5 min, diary only)"])
-    DigestToday(["auto_digest.py --today\n(every 15 min, infer=True, mem0 dedup)"])
+    DigestToday(["auto_digest.py --today\n(every 15 min, infer=False, direct text)"])
     Sync(["memory_sync.py\n(daily UTC 01:00, MEMORY.md)"])
     Archive(["auto_dream.py\n(AutoDream, UTC 02:00)"])
 
@@ -90,7 +90,7 @@ flowchart TD
     Agents -- "active write\n(no run_id)" --> LTM
     Agents -- "actively maintain" --> MemoryMD
     Snap --> Diary
-    Diary -- "every 15 min\n(50KB batches, infer=True)" --> DigestToday
+    Diary -- "every 15 min\n(50KB batches, infer=False)" --> DigestToday
     MemoryMD -- "daily UTC 01:00\n(hash dedup)" --> Sync
     DigestToday --> STM
     Sync --> LTM
@@ -114,7 +114,7 @@ flowchart TD
 | Component | Role |
 |---|---|
 | **session_snapshot.py** | Runs every 5 minutes. Captures **all** agent sessions (direct chat + group chats) into daily diary files. **Does not write to mem0 directly** — mem0 ingestion is handled entirely by auto_digest. |
-| **auto_digest.py --today** | Runs every 15 minutes. Reads only the **new bytes** added since the last run (tracked via `auto_digest_offset.json`). Sends content to mem0 in **section-aligned batches** (up to ~50KB each, aligned to `## ` diary section boundaries) with `infer=True` — mem0 handles fact extraction and deduplication automatically. Offset is persisted after each successful batch, enabling crash-safe resume. |
+| **auto_digest.py --today** | Runs every 15 minutes. Reads only the **new bytes** added since the last run (tracked via `auto_digest_offset.json`). Sends content to mem0 in **section-aligned batches** (up to ~50KB each, aligned to `## ` diary section boundaries) with `infer=False` — diary text is passed directly to mem0 without a custom LLM extraction layer. Offset is persisted after each successful batch, enabling crash-safe resume. |
 | **memory_sync.py** | Runs daily at UTC 01:00. Syncs each agent's `MEMORY.md` (curated knowledge) directly to mem0 long-term memory. Hash-based dedup skips unchanged files — zero LLM cost if nothing changed. |
 | **auto_dream.py** / **AutoDream** | Runs daily at UTC 02:00. **Step 1**: reads yesterday's complete diary → `mem0.add(infer=True, no run_id)` → long-term memory. **Step 2**: for each 7-day-old short-term memory, calls `mem0.add(infer=True, no run_id)` — mem0 LLM compares against existing long-term memories and returns a decision: `ADD` (new knowledge, write), `UPDATE` (merge with existing), `DELETE` (redundant, skip write), or `NONE` (already covered). Regardless of decision, the original short-term entry is always deleted after processing. |
 | **mem0 Memory Service** | Core service. Uses AWS Bedrock LLM for memory distillation/deduplication and Bedrock Embedding for vectorization. |
@@ -125,7 +125,7 @@ flowchart TD
 
 ```
 Every 5 min   session_snapshot    — conversations → diary files  (no mem0 write)
-Every 15 min  auto_digest --today — diary new bytes → mem0 short-term  (infer=True, mem0 dedup)
+Every 15 min  auto_digest --today — diary new bytes → mem0 short-term  (infer=False, direct text)
 01:00         memory_sync         — MEMORY.md → mem0 long-term  (curated knowledge, instant)
 02:00         auto_dream          — Step1: yesterday diary → long-term (infer=True)
                                     Step2: 7-day-old short-term → re-add (infer=True) + delete
@@ -192,13 +192,13 @@ When mem0 receives a write with `infer=True`, it runs a semantic dedup search to
 
 | Write | Dedup scope | Effect |
 |-------|-------------|--------|
-| `auto_digest --today` (with `run_id=YYYY-MM-DD`) | Only same-day entries | Today's short-term memories dedup against each other; don't disturb long-term |
+| `auto_digest --today` (with `run_id=YYYY-MM-DD`) | Only same-day entries | Today's short-term memories are stored directly (infer=False); no LLM dedup at write time |
 | `auto_dream` consolidate (no `run_id`) | All long-term entries (no run_id) | 7-day-old short-term memories globally dedup against entire long-term history |
 
 This boundary has two important consequences:
 
 **1. Short-term writes are safe and cheap.**
-`auto_digest` runs every 15 minutes. Because it writes with `run_id=today`, it only deduplicates within today's entries. It never triggers a global search across all long-term memories — keeping costs low and writes fast.
+`auto_digest` runs every 15 minutes. Because it writes with `infer=False`, no LLM extraction or dedup is triggered at write time — keeping costs minimal and writes fast.
 
 **2. Global dedup happens exactly once, at promotion time.**
 When `auto_dream` promotes a short-term memory to long-term (re-add with no `run_id`), mem0 searches across the entire long-term store. This is the moment where redundant, updated, or already-covered knowledge gets merged. The result: **long-term memory stays compact and non-redundant**, even after months of daily operation.
@@ -211,7 +211,7 @@ In practice, we observed 1,800 short-term entries consolidating down to ~78 long
 
 **`auto_digest.py --today` (every 15 min, incremental)**
 
-Runs every 15 minutes, reading only new diary content since the last run. Sends **section-aligned batches** (up to ~50KB each, aligned to `## ` diary section boundaries) to mem0 with `infer=True` — mem0 handles fact extraction and deduplication automatically. Offset is saved after each successful batch — if the process is interrupted, the next run picks up where it left off.
+Runs every 15 minutes, reading only new diary content since the last run. Sends **section-aligned batches** (up to ~50KB each, aligned to `## ` diary section boundaries) to mem0 with `infer=False` — diary text is passed directly without a custom LLM extraction layer. Offset is saved after each successful batch — if the process is interrupted, the next run picks up where it left off.
 
 This provides **real-time cross-session memory**: conversations from the last ~15 minutes are available for retrieval in other sessions of the same agent.
 

--- a/docs/guide/how-it-works.md
+++ b/docs/guide/how-it-works.md
@@ -90,8 +90,8 @@ On every heartbeat tick, the agent performs memory maintenance in order:
          Heartbeat      Every 15min    UTC 02:00      UTC 01:00
          (agent         auto_digest    auto_dream     memory_sync
           self-         --today        (Step1:        (sync
-          distills)     (infer=True,   yesterday      MEMORY.md)
-                        mem0 dedup)    diary +
+          distills)     (infer=False,  yesterday      MEMORY.md)
+                        direct text)   diary +
                                        Step2: 7d STM)
               │             │              │              │
               ▼             ▼              ▼              ▼
@@ -130,7 +130,7 @@ For deployment details, see [Docker Setup](../deploy/docker) or [systemd Setup](
 | Time (UTC) | Script | What it does |
 |-----------|--------|--------------|
 | Every 5 min | `pipelines/session_snapshot.py` | Capture session conversations → diary file |
-| Every 15 min | `pipelines/auto_digest.py --today` | Incremental: read new diary content → mem0 short-term (infer=True, mem0 handles dedup) |
+| Every 15 min | `pipelines/auto_digest.py --today` | Incremental: read new diary content → mem0 short-term (infer=False, direct text) |
 | 01:00 | `pipelines/memory_sync.py` | Sync `MEMORY.md` → mem0 long-term (hash dedup) |
 | 02:00 | `pipelines/auto_dream.py` | **AutoDream**: Step 1: yesterday diary → mem0 long-term (infer=True); Step 2: 7-day-old short-term → re-add to long-term (infer=True) then delete |
 
@@ -141,15 +141,15 @@ For deployment details, see [Docker Setup](../deploy/docker) or [systemd Setup](
 `auto_digest.py` runs in one active mode:
 
 **`--today` mode (every 15 min, incremental)**
-Picks up new content from today's diary since the last run (offset-based). Writes to mem0 short-term memory with `infer=True` — mem0 handles fact extraction and deduplication automatically. Skips batches smaller than 500 bytes to avoid noisy micro-writes. On failure, retains the offset so the next run resumes from the same point.
+Picks up new content from today's diary since the last run (offset-based). Writes to mem0 short-term memory with `infer=False` — diary text is passed directly to mem0 without a custom LLM extraction layer. Skips batches smaller than 500 bytes to avoid noisy micro-writes. On failure, retains the offset so the next run resumes from the same point.
 
 ```
-Every 15 min (--today):  diary new content → POST to mem0 (infer=True, mem0 dedup)
+Every 15 min (--today):  diary new content → POST to mem0 (infer=False, direct text)
 ```
 
 **Why short-term entries don't pollute long-term memory**
 
-`auto_digest` writes with a `run_id = YYYY-MM-DD`. This is the key that controls mem0's dedup scope: when `infer=True` is used, mem0 searches for similar memories **only within the same `run_id`**. So today's entries dedup against each other, but never interfere with existing long-term memories (which have no `run_id`).
+`auto_digest` writes with a `run_id = YYYY-MM-DD`. This is the key that controls mem0's dedup scope: when `infer=True` is used, mem0 searches for similar memories **only within the same `run_id`**. Since `auto_digest` now uses `infer=False`, no LLM dedup is triggered at write time. Today's entries are stored directly without interfering with existing long-term memories (which have no `run_id`).
 
 This means:
 - Writing every 15 minutes is safe — no risk of silently overwriting long-term knowledge
@@ -179,7 +179,7 @@ When a session's context window grows too large, OpenClaw compresses (compacts) 
 **Tertiary: Near-real-time cross-session memory sharing**
 Each agent may have multiple concurrent sessions — a direct chat session and one or more group chat sessions. Without a sharing mechanism, what an agent says in a group chat is invisible to its direct chat session (and vice versa).
 
-`session_snapshot.py` writes new conversation to the diary file every 5 minutes. `auto_digest.py --today` then picks up new diary content every 15 minutes and writes it to mem0 short-term memory with `infer=True` (run_id=today, mem0 handles dedup). Any other session of the same agent can search mem0 and retrieve that content within ~20 minutes (5 min snapshot + 15 min digest) — no session restart required.
+`session_snapshot.py` writes new conversation to the diary file every 5 minutes. `auto_digest.py --today` then picks up new diary content every 15 minutes and writes it to mem0 short-term memory with `infer=False` (run_id=today, direct text). Any other session of the same agent can search mem0 and retrieve that content within ~20 minutes (5 min snapshot + 15 min digest) — no session restart required.
 
 Session keys are tagged in metadata (`session_key`), so you can filter by source if needed.
 

--- a/docs/zh/deploy/systemd.md
+++ b/docs/zh/deploy/systemd.md
@@ -28,7 +28,7 @@ systemctl --user enable --now mem0-snapshot.timer
 
 ### 自动摘要（每 15 分钟）
 
-从日记文件中提取短期事件，以 `infer=True` 和 `run_id=YYYY-MM-DD` 的形式存入 mem0。mem0 自动处理事实提取和去重。
+从日记文件中提取短期事件，以 `infer=False` 和 `run_id=YYYY-MM-DD` 的形式存入 mem0。日记文本直接传入，不经过自定义 LLM 提取层。
 
 ```bash
 # 使用 cron

--- a/docs/zh/guide/architecture.md
+++ b/docs/zh/guide/architecture.md
@@ -67,7 +67,7 @@ flowchart TD
     Diary["memory/YYYY-MM-DD.md\n（日记文件）"]
     MemoryMD["MEMORY.md\n（Agent 精选知识库）"]
     Snap(["session_snapshot.py\n（每 5 分钟，仅写日记）"])
-    DigestToday(["auto_digest.py --today\n（每 15 分钟，infer=True，mem0 去重）"])
+    DigestToday(["auto_digest.py --today\n（每 15 分钟，infer=False，直接传文本）"])
     Sync(["memory_sync.py\n（每天 UTC 01:00，同步 MEMORY.md）"])
     Archive(["auto_dream.py\n(AutoDream，UTC 02:00)"])
 
@@ -90,7 +90,7 @@ flowchart TD
     Agents -- "主动写入\n（无 run_id）" --> LTM
     Agents -- "主动维护" --> MemoryMD
     Snap --> Diary
-    Diary -- "每 15 分钟\n（50KB 分批，infer=True）" --> DigestToday
+    Diary -- "每 15 分钟\n（50KB 分批，infer=False）" --> DigestToday
     MemoryMD -- "每天 UTC 01:00\n（hash 去重）" --> Sync
     DigestToday --> STM
     Sync --> LTM
@@ -114,7 +114,7 @@ flowchart TD
 | 组件 | 职责 |
 |---|---|
 | **session_snapshot.py** | 每 5 分钟运行一次。捕获**所有** Agent 会话（单聊 + 群聊）到日记文件。**不直接写入 mem0**——mem0 的写入完全由 auto_digest 负责。 |
-| **auto_digest.py --today** | 每 15 分钟运行一次。读取自上次运行以来日记文件中的**新增字节**（通过 `auto_digest_offset.json` 追踪），以**按 `## ` 章节边界对齐的分批**（每批最大约 50KB）加 `infer=True` 写入 mem0——mem0 自动处理事实提取和去重。每批成功后立即持久化 offset，支持断点续传。 |
+| **auto_digest.py --today** | 每 15 分钟运行一次。读取自上次运行以来日记文件中的**新增字节**（通过 `auto_digest_offset.json` 追踪），以**按 `## ` 章节边界对齐的分批**（每批最大约 50KB）加 `infer=False` 写入 mem0——日记文本直接传入，不经过自定义 LLM 提取层。每批成功后立即持久化 offset，支持断点续传。 |
 | **memory_sync.py** | 每天 UTC 01:00 运行。将各 Agent 的 `MEMORY.md`（精选知识）直接同步到 mem0 长期记忆。基于 hash 去重，文件未变化时零 LLM 调用。 |
 | **auto_dream.py** / **AutoDream** | 每天 UTC 02:00 运行。**步骤一**：读取昨日完整日记 → `mem0.add(infer=True, 无 run_id)` → 长期记忆。**步骤二**：对每条 7 天前的短期记忆，调用 `mem0.add(infer=True, 无 run_id)`——mem0 LLM 与已有长期记忆比对，返回四种决策之一：`ADD`（新知识，写入）、`UPDATE`（与已有条目合并）、`DELETE`（冗余，跳过写入）、`NONE`（已完全覆盖，跳过写入）。无论何种决策，**原始短期条目处理后始终删除**。 |
 | **mem0 Memory Service** | 核心服务。使用 AWS Bedrock LLM 进行记忆提炼与去重，使用 Bedrock Embedding 进行向量化。 |
@@ -125,7 +125,7 @@ flowchart TD
 
 ```
 每 5 分钟    session_snapshot    — 对话 → 日记文件（不写 mem0）
-每 15 分钟   auto_digest --today — 日记新增内容 → mem0 短期记忆（infer=True，mem0 去重）
+每 15 分钟   auto_digest --today — 日记新增内容 → mem0 短期记忆（infer=False，直接传文本）
 01:00        memory_sync         — MEMORY.md → mem0 长期记忆（精选知识，即时生效）
 02:00        auto_dream          — 步骤一：昨日日记 → 长期记忆（infer=True）
                                    步骤二：7天前短期记忆 → 重新写入（infer=True）+ 删除
@@ -190,7 +190,7 @@ run_id = 不传           →  长期记忆（永久保存）
 
 **`auto_digest.py --today`（每 15 分钟，增量）**
 
-每 15 分钟运行一次，只读取自上次运行以来的新增内容。以**按 `## ` 章节边界对齐的分批**（每批最大约 50KB）加 `infer=True` 发给 mem0——mem0 自动做 fact extraction 和去重。每批成功后立即保存 offset——即使进程中断，下次运行也能从断点继续。
+每 15 分钟运行一次，只读取自上次运行以来的新增内容。以**按 `## ` 章节边界对齐的分批**（每批最大约 50KB）加 `infer=False` 发给 mem0——日记文本直接传入，不经过自定义 LLM 提取层。每批成功后立即保存 offset——即使进程中断，下次运行也能从断点继续。
 
 这提供了**实时跨 session 记忆**：最近 ~15 分钟的对话可在同一 agent 的其他 session 中被检索到。
 

--- a/docs/zh/guide/how-it-works.md
+++ b/docs/zh/guide/how-it-works.md
@@ -90,8 +90,8 @@ Agent 读到「🔴 Agent Memory Behavior」规则
           Heartbeat      每 15 分钟     UTC 02:00      UTC 01:00
           （agent        auto_digest   auto_dream     memory_sync
            自我提炼）    --today       （Step1:        （同步
-                         (infer=True,   昨日日记 +     MEMORY.md）
-                          mem0 去重）    Step2: 7天STM）
+                         (infer=False,  昨日日记 +     MEMORY.md）
+                          直接传文本）  Step2: 7天STM）
               │             │              │              │
               ▼             ▼              ▼              ▼
           MEMORY.md     mem0 短期记忆  mem0 短期记忆  mem0 长期记忆
@@ -129,7 +129,7 @@ Agent 读到「🔴 Agent Memory Behavior」规则
 | 时间（UTC） | 脚本 | 做什么 |
 |------------|------|--------|
 | 每 5 分钟 | `pipelines/session_snapshot.py` | 捕获会话对话 → 日记文件 |
-| 每 15 分钟 | `pipelines/auto_digest.py --today` | 增量模式：读取日记新增内容 → mem0 短期记忆（infer=True，mem0 自动去重） |
+| 每 15 分钟 | `pipelines/auto_digest.py --today` | 增量模式：读取日记新增内容 → mem0 短期记忆（infer=False，直接传文本） |
 | 01:00 | `pipelines/memory_sync.py` | 同步 `MEMORY.md` → mem0 长期记忆（hash 去重） |
 | 02:00 | `pipelines/auto_dream.py` | **AutoDream**：Step1: 昨日日记 → mem0 长期记忆（infer=True）；Step2: 7天前短期记忆 → re-add 到长期（infer=True）后删除 |
 
@@ -140,10 +140,10 @@ Agent 读到「🔴 Agent Memory Behavior」规则
 `auto_digest.py` 只有一种活跃模式：
 
 **`--today` 增量模式（每 15 分钟）**
-基于 offset 记录，每次只读取日记文件自上次运行以来的新增内容。以 `infer=True` 写入 mem0，由 mem0 自动做 fact extraction 和去重。新增内容不足 500 字节时跳过，避免无意义的小写入。写入失败时保留 offset，下次从同一断点续传。
+基于 offset 记录，每次只读取日记文件自上次运行以来的新增内容。以 `infer=False` 写入 mem0，日记文本直接传入，不经过自定义 LLM 提取层。新增内容不足 500 字节时跳过，避免无意义的小写入。写入失败时保留 offset，下次从同一断点续传。
 
 ```
-每 15 分钟 (--today)：  日记新增内容 → POST 给 mem0（infer=True，mem0 去重）
+每 15 分钟 (--today)：  日记新增内容 → POST 给 mem0（infer=False，直接传文本）
 ```
 
 > **注**：之前的默认全量模式（UTC 01:30，LLM 提取昨日日记 → mem0 短期记忆）已被 `auto_dream.py` Step 1 取代——后者直接写入长期记忆（无 run_id），质量更高。
@@ -161,7 +161,7 @@ Agent 每天重置。没有 snapshot，session 之间的对话就会丢失。Sna
 **第三个角色：近实时跨 session 记忆共享**
 同一个 agent 可能有多个并发 session——一个单聊 session 和一个或多个群聊 session。没有共享机制的话，agent 在群聊里说的内容，单聊 session 完全看不到（反之亦然）。
 
-`session_snapshot.py` 每 5 分钟将新对话写入日记文件，`auto_digest.py --today` 再每 15 分钟增量读取日记新增内容，以 `infer=True` 写入 mem0 短期记忆（run_id=今天，mem0 自动去重）。同一 agent 的其他 session 搜索 mem0 即可在约 **20 分钟内**（5 分钟 snapshot + 15 分钟 digest）获取到这些内容——无需重启 session。
+`session_snapshot.py` 每 5 分钟将新对话写入日记文件，`auto_digest.py --today` 再每 15 分钟增量读取日记新增内容，以 `infer=False` 写入 mem0 短期记忆（run_id=今天，直接传文本）。同一 agent 的其他 session 搜索 mem0 即可在约 **20 分钟内**（5 分钟 snapshot + 15 分钟 digest）获取到这些内容——无需重启 session。
 
 session 来源记录在 metadata 的 `session_key` 字段中，需要时可按来源过滤。
 


### PR DESCRIPTION
Follow-up to #63. After removing the custom LLM extraction layer from auto_digest, it now passes diary text directly to mem0 with infer=False. Update all doc references accordingly.

Note: auto_dream still uses infer=True (unchanged).