### PR TITLE
fix: use UTC date consistently (#67)

### DIFF
--- a/pipelines/auto_digest.py
+++ b/pipelines/auto_digest.py
@@ -3,7 +3,7 @@
 auto_digest.py - 自动从日记文件提取短期记忆
 
 两种模式：
-  默认模式：每天 UTC 01:30 运行，读取北京时间昨天的完整日记，分批 POST 给 mem0（infer=True，由 mem0 内部做 fact extraction）
+  默认模式：每天 UTC 01:30 运行，读取 UTC 昨天的完整日记，分批 POST 给 mem0（infer=True，由 mem0 内部做 fact extraction）
   --today 模式：每 15 分钟增量运行，读取今天日记的新增部分，分批 POST 给 mem0（由 mem0 内部做 fact extraction）
 """
 import argparse
@@ -94,19 +94,14 @@ def load_agent_workspaces() -> dict:
     return mapping
 
 
-def get_beijing_yesterday() -> str:
-    """获取北京时间昨天的日期字符串"""
-    utc_now = datetime.utcnow()
-    beijing_now = utc_now + timedelta(hours=8)
-    yesterday = beijing_now - timedelta(days=1)
-    return yesterday.strftime("%Y-%m-%d")
+def get_utc_yesterday() -> str:
+    """获取 UTC 昨天的日期字符串"""
+    return (datetime.utcnow() - timedelta(days=1)).strftime("%Y-%m-%d")
 
 
-def get_beijing_today() -> str:
-    """获取北京时间今天的日期字符串"""
-    utc_now = datetime.utcnow()
-    beijing_now = utc_now + timedelta(hours=8)
-    return beijing_now.strftime("%Y-%m-%d")
+def get_utc_today() -> str:
+    """获取 UTC 今天的日期字符串"""
+    return datetime.utcnow().strftime("%Y-%m-%d")
 
 
 # ─── Offset Management (for incremental mode) ───
@@ -316,7 +311,7 @@ def main():
 
     if args.today:
         # 今日增量模式
-        today = get_beijing_today()
+        today = get_utc_today()
         logger.info(f"Starting auto_digest.py --today (incremental, date={today})")
         offsets = load_offsets()
 
@@ -332,7 +327,7 @@ def main():
         logger.info("Incremental digest completed")
     else:
         # 昨日全量模式（原有逻辑）
-        yesterday = get_beijing_yesterday()
+        yesterday = get_utc_yesterday()
         logger.info(f"Starting auto_digest.py (full mode, date={yesterday})")
 
         for agent_id, workspace in sorted(workspaces.items()):

--- a/pipelines/auto_dream.py
+++ b/pipelines/auto_dream.py
@@ -123,10 +123,8 @@ def load_agent_workspaces() -> dict[str, Path]:
 
 # ─── Helpers ───
 
-def get_beijing_yesterday() -> str:
-    tz_beijing = timezone(timedelta(hours=8))
-    yesterday = datetime.now(tz_beijing).date() - timedelta(days=1)
-    return yesterday.strftime("%Y-%m-%d")
+def get_utc_yesterday() -> str:
+    return (datetime.utcnow() - timedelta(days=1)).strftime("%Y-%m-%d")
 
 
 def get_short_term_memories(agent_id: str, run_id: str) -> list:
@@ -163,7 +161,7 @@ def delete_memory(memory_id: str):
 
 def digest_yesterday(agent_id: str, workspace: Path):
     """读取昨日日记 → POST mem0.add(infer=True, 无 run_id) → 长期记忆"""
-    yesterday = get_beijing_yesterday()
+    yesterday = get_utc_yesterday()
     diary_file = workspace / "memory" / f"{yesterday}.md"
     if not diary_file.exists():
         logger.info(f"[{agent_id}] No diary for {yesterday}, skipping digest")
@@ -233,12 +231,12 @@ def main():
     logger.info("=" * 80)
     logger.info("Starting auto_dream.py (AutoDream consolidation)")
 
-    tz_beijing = timezone(timedelta(hours=8))
-    today = datetime.now(tz_beijing).date()
+    tz_utc = timezone.utc
+    today = datetime.now(tz_utc).date()
     target_date = today - timedelta(days=ARCHIVE_DAYS)
     target_run_id = target_date.strftime("%Y-%m-%d")
 
-    logger.info(f"Beijing date: {today}")
+    logger.info(f"UTC date: {today}")
     logger.info(f"Target run_id for consolidation: {target_run_id}")
 
     workspaces = load_agent_workspaces()

--- a/pipelines/session_snapshot.py
+++ b/pipelines/session_snapshot.py
@@ -21,7 +21,7 @@ import json
 import logging
 import re
 import time
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timedelta
 from pathlib import Path
 
 import requests
@@ -42,7 +42,6 @@ DATA_DIR = Path(os.environ.get("DATA_DIR", Path(__file__).parent.parent))
 # mem0 配置
 MEM0_API_URL = os.environ.get("MEM0_API_URL", "http://127.0.0.1:8230")
 USER_ID = "boss"
-BJT = timezone(timedelta(hours=8))
 OFFSET_FILE = DATA_DIR / ".snapshot_offsets.json"
 
 # 噪音模式：需要过滤的内容
@@ -199,14 +198,14 @@ def get_today_memory_path(agent_id: str) -> Path:
         workspace = OPENCLAW_BASE / f"workspace-{agent_id}"
     memory_dir = workspace / "memory"
     memory_dir.mkdir(parents=True, exist_ok=True)
-    today = datetime.now().strftime("%Y-%m-%d")
+    today = datetime.utcnow().strftime("%Y-%m-%d")
     return memory_dir / f"{today}.md"
 
 
 def init_memory_file(path: Path, agent_id: str) -> None:
     """初始化日记文件头"""
     if not path.exists():
-        date_str = datetime.now().strftime("%Y-%m-%d")
+        date_str = datetime.utcnow().strftime("%Y-%m-%d")
         label = agent_id.capitalize()
         content = f"""# {date_str} - {label} Agent 日记
 
@@ -527,7 +526,7 @@ def process_agent(agent_id: str) -> None:
         return
 
     diary_path = get_today_memory_path(agent_id)
-    today = datetime.now(BJT).strftime("%Y-%m-%d")
+    today = datetime.utcnow().strftime("%Y-%m-%d")
     offsets = load_offsets()
 
     for session_key, session_path in sessions:


### PR DESCRIPTION
Removes all Beijing timezone (+8h) conversions across the pipeline:\n\n- `auto_digest.py`: `get_beijing_today/yesterday()` → `get_utc_today/yesterday()`\n- `auto_dream.py`: `get_beijing_yesterday()` → `get_utc_yesterday()`, `tz_beijing` → UTC\n- `session_snapshot.py`: `BJT` removed, all `datetime.now()` → `datetime.utcnow()`\n\nFixes the 8-hour window where `auto_digest --today` found no diary files after UTC 16:00 (Beijing midnight).\n\nCloses #67