### PR TITLE
fix: remove path suffix from MEM0_API_URL in docker-compose.yml (#69)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,7 +57,7 @@ services:
     environment:
       - OPENCLAW_BASE=/openclaw
       - DATA_DIR=/app/data
-      - MEM0_API_URL=http://mem0-api:8230/memory/add
+      - MEM0_API_URL=http://mem0-api:8230
     depends_on:
       mem0-api:
         condition: service_healthy


### PR DESCRIPTION
## 修复

`docker-compose.yml` 中 `MEM0_API_URL` 错误地包含了路径后缀 `/memory/add`，导致 pipeline 脚本拼接路径后变成 `/memory/add/memory/add` → 404。

## 变更

```yaml
- MEM0_API_URL=http://mem0-api:8230/memory/add
+ MEM0_API_URL=http://mem0-api:8230
```

## 影响

修复后 auto_dream 每天 UTC 02:00 可正常归档短期记忆为长期记忆。

Closes #69