### PR TITLE
fix: normalize MEM0_API_URL in auto_digest.py to support base URL format

### DIFF
--- a/pipelines/auto_digest.py
+++ b/pipelines/auto_digest.py
@@ -28,7 +28,9 @@ DATA_DIR = Path(os.environ.get("DATA_DIR", Path(__file__).parent.parent))
 
 LOG_FILE = DATA_DIR / "auto_digest.log"
 OFFSET_FILE = DATA_DIR / "auto_digest_offset.json"
-MEM0_API_URL = os.environ.get("MEM0_API_URL", "http://127.0.0.1:8230/memory/add")
+_raw_url = os.environ.get("MEM0_API_URL", "http://127.0.0.1:8230")
+MEM0_BASE_URL = _raw_url.removesuffix("/memory/add").removesuffix("/")
+MEM0_API_URL = f"{MEM0_BASE_URL}/memory/add"
 MIN_CONTENT_BYTES = 500   # 新增内容少于此值则跳过（避免无意义的小更新）
 BATCH_SIZE_BYTES = 50000  # 每批读取的字节数（50KB）
 BATCH_SLEEP_SECS = 5      # 批次间 sleep，避免打爆 mem0


### PR DESCRIPTION
## 问题

PR #70 将 `docker-compose.yml` 中 `MEM0_API_URL` 改为 base URL（`http://mem0-api:8230`），但 `auto_digest.py` 直接把 `MEM0_API_URL` 当 POST endpoint 使用，导致请求打到 `/` → 404。

`auto_dream.py` 是自己拼 `/memory/add`，两者设计不一致。

## 修复

用 `removesuffix` 兼容旧格式（含路径）和新格式（base URL）：

```python
_raw_url = os.environ.get("MEM0_API_URL", "http://127.0.0.1:8230")
MEM0_BASE_URL = _raw_url.removesuffix("/memory/add").removesuffix("/")
MEM0_API_URL = f"{MEM0_BASE_URL}/memory/add"
```

无论 env var 是 `http://host:8230` 还是旧的 `http://host:8230/memory/add`，都能正确拼出 endpoint。