### PR TITLE
fix: increase write_to_mem0 timeout from 30s to 120s (#73)

### DIFF
--- a/pipelines/auto_digest.py
+++ b/pipelines/auto_digest.py
@@ -146,7 +146,7 @@ def write_to_mem0(event: str, run_id: str, agent_id: str, incremental: bool = Fa
             "text": event,
             "infer": True,
             "metadata": metadata
-        }, timeout=30)
+        }, timeout=120)
         resp.raise_for_status()
         logger.info(f"✓ Wrote to mem0: {event[:80]}...")
         return True


### PR DESCRIPTION
## 修复

将 `auto_digest.py` 中 `write_to_mem0()` 的 HTTP timeout 从 30s 改为 120s，与 `auto_dream.py` 保持一致。

mem0 `/memory/add` 在 `infer=True` 模式下调用 Bedrock LLM 做 fact extraction，响应时间不稳定，30s 容易触发 ReadTimeout 导致写入失败。

Closes #73