### PR TITLE
optimize: increase BATCH_SIZE 50KB→200KB, MIN_CONTENT 500→5000 bytes (#75)

### DIFF
--- a/pipelines/auto_digest.py
+++ b/pipelines/auto_digest.py
@@ -31,8 +31,8 @@ OFFSET_FILE = DATA_DIR / "auto_digest_offset.json"
 _raw_url = os.environ.get("MEM0_API_URL", "http://127.0.0.1:8230")
 MEM0_BASE_URL = _raw_url.removesuffix("/memory/add").removesuffix("/")
 MEM0_API_URL = f"{MEM0_BASE_URL}/memory/add"
-MIN_CONTENT_BYTES = 500   # 新增内容少于此值则跳过（避免无意义的小更新）
-BATCH_SIZE_BYTES = 50000  # 每批读取的字节数（50KB）
+MIN_CONTENT_BYTES = 5000   # 新增内容少于此值则跳过（避免无意义的小更新）
+BATCH_SIZE_BYTES = 200000  # 每批读取的字节数（200KB）
 BATCH_SLEEP_SECS = 5      # 批次间 sleep，避免打爆 mem0
 
 # ─── Setup Logging ───


### PR DESCRIPTION
## 优化内容

减少 auto_digest 的 LLM 调用频率，降低 token 消耗。

| 参数 | 旧值 | 新值 |
|------|------|------|
| `BATCH_SIZE_BYTES` | 50,000（50KB） | 200,000（200KB） |
| `MIN_CONTENT_BYTES` | 500 | 5,000 |

## 预期效果

- 批次大小 4x → 相同内容下 LLM calls 减少约 75%
- 跳过 5KB 以下的碎小更新，避免频繁小批次写入
- 预计整体 token 消耗降低 60~70%

## 背景数据

当前 8 天累计消耗 6149 万 tokens，auto_digest 是主要来源。

Closes #75 (partial — A+B 方案)