### PR TITLE
fix: set infer=False in auto_digest write_to_mem0 (#81)

### DIFF
--- a/pipelines/auto_digest.py
+++ b/pipelines/auto_digest.py
@@ -3,7 +3,7 @@
 auto_digest.py - 自动从日记文件提取短期记忆
 
 两种模式：
-  默认模式：每天 UTC 01:30 运行，读取 UTC 昨天的完整日记，分批 POST 给 mem0（infer=True，由 mem0 内部做 fact extraction）
+  默认模式：每天 UTC 01:30 运行，读取 UTC 昨天的完整日记，分批 POST 给 mem0（infer=False，直接存储不触发 LLM 推理）
   --today 模式：每 15 分钟增量运行，读取今天日记的新增部分，分批 POST 给 mem0（由 mem0 内部做 fact extraction）
 """
 import argparse
@@ -144,7 +144,7 @@ def write_to_mem0(event: str, run_id: str, agent_id: str, incremental: bool = Fa
             "agent_id": agent_id,
             "run_id": run_id,
             "text": event,
-            "infer": True,
+            "infer": False,
             "metadata": metadata
         }, timeout=120)
         resp.raise_for_status()
@@ -244,7 +244,7 @@ def process_agent(agent_id: str, workspace: Path, date: str, incremental: bool =
         return {"status": status, "new_bytes": total_new, "memories_added": 0, "batches_sent": batches_sent}
 
     else:
-        # 全量模式：读取整个文件，分批直接 POST 给 mem0（infer=True，由 mem0 内部做 fact extraction）
+        # 全量模式：读取整个文件，分批直接 POST 给 mem0（infer=False，直接存储不触发 LLM 推理）
         content = diary_file.read_text(encoding='utf-8')
         logger.info(f"[{agent_id}] Full mode: processing diary for {date} ({file_size} bytes)")
 


### PR DESCRIPTION
## 修复

将 `auto_digest.py` 中 `write_to_mem0()` 的 `infer=True` 改为 `infer=False`。

`infer=True` 会触发 mem0 内部 LLM pipeline（fact extraction + deduplication），把日记内容和已有记忆对比后 merge，导致记忆条数不增长。

设计意图（PR #63/64）是直接存储日记文本，不做 LLM 推理。代码和文档不一致，此 PR 修正代码。

Closes #81