### PR TITLE
fix: pass limit=10000 to memory.get_all() to bypass default limit=100 (#83)

### DIFF
--- a/server.py
+++ b/server.py
@@ -369,6 +369,7 @@ async def list_memories(
     try:
         loop = asyncio.get_event_loop()
         kw = dict(kwargs)
+        kw["limit"] = 10000  # override mem0 default limit=100 to fetch all memories (#83)
         all_results = await loop.run_in_executor(_mem0_executor, lambda: memory.get_all(**kw))
         # Normalize: get_all may return dict with "results" key or a list
         if isinstance(all_results, dict) and "results" in all_results:


### PR DESCRIPTION
mem0 get_all() 默认 limit=100，导致 /memory/list 只返回 100 条，数据库实际 791 条。\n\n传入 limit=10000 拿全量，再由 server.py 层做分页。\n\nCloses #83