### PR TITLE
docs: MEMORY.md slim guide + session start recall in best-practices (#93)

### DIFF
--- a/docs/guide/best-practices.md
+++ b/docs/guide/best-practices.md
@@ -2,6 +2,35 @@
 
 After deploying mem0 Memory Service, the real value comes from **tuning your agents** to actively use the memory system. This guide provides ready-to-use prompts you can paste directly to your OpenClaw agent.
 
+## Core Principle: Static vs Dynamic Separation
+
+OpenClaw loads all Project Context files (MEMORY.md, SOUL.md, AGENTS.md, etc.) into every session's context. This is the biggest source of token waste:
+
+```
+Before optimization:
+  MEMORY.md (full, 80+ lines) → loaded every session regardless of task
+  = 90% of content irrelevant to current task
+
+After optimization:
+  MEMORY.md (skeleton, ~25 lines) → stable index only
+  mem0 (dynamic memories) → recalled on-demand by relevance
+  = Only relevant context loaded per task
+```
+
+**Rule of thumb for MEMORY.md:**
+
+| Keep in MEMORY.md | Move to mem0 |
+|---|---|
+| Project name + GitHub URL + local path | PR status, recent progress |
+| Service ports, systemd names | Technical decisions and rationale |
+| Key team member IDs | Pitfalls, lessons learned |
+| One-line project description | Workflow conventions and rules |
+| | Pending tasks (use GitHub Issues instead) |
+
+**Target: MEMORY.md under 30 lines per agent. Token savings: 60–80% on MEMORY.md alone.**
+
+---
+
 ## One-Time Setup (Run After Deployment)
 
 ### 1. Slim Down MEMORY.md

--- a/docs/zh/guide/best-practices.md
+++ b/docs/zh/guide/best-practices.md
@@ -2,6 +2,35 @@
 
 部署 mem0 Memory Service 之后，真正的价值来自于**调教好你的 Agent**，让它主动使用记忆系统。本文提供可直接复制粘贴给 OpenClaw Agent 的提示词。
 
+## 核心原则：静态 vs 动态分离
+
+OpenClaw 会把所有 Project Context 文件（MEMORY.md、SOUL.md、AGENTS.md 等）全量注入每次 session 的 context，这是 token 浪费的最大来源：
+
+```
+优化前：
+  MEMORY.md（完整版，80+ 行）→ 每次 session 全量加载，不管任务是什么
+  = 90% 的内容与当前任务无关
+
+优化后：
+  MEMORY.md（骨架版，~25 行）→ 只保留稳定索引
+  mem0（动态记忆）→ 按相关性按需召回
+  = 每次任务只加载相关的上下文
+```
+
+**MEMORY.md 内容取舍标准：**
+
+| 留在 MEMORY.md | 移到 mem0 |
+|---|---|
+| 项目名称 + GitHub URL + 本地路径 | PR 状态、近期进展 |
+| 服务端口、systemd 服务名 | 技术决策及原因 |
+| 关键团队成员的 ID | 踩坑记录、经验教训 |
+| 一句话项目描述 | 工作流规范细节 |
+| | 待办事项（用 GitHub Issues 代替）|
+
+**目标：每个 agent 的 MEMORY.md 控制在 30 行以内。仅此一项可节省 MEMORY.md 60–80% 的 token。**
+
+---
+
 ## 一次性初始化（部署后执行一次）
 
 ### 1. 精简 MEMORY.md


### PR DESCRIPTION
## 变更内容

### best-practices.md（英中双语）
在文档最前面新增「核心原则：静态 vs 动态分离」章节：
- 解释为什么 MEMORY.md 全量注入是 token 浪费的根源
- 提供「留/移」决策表：什么内容留在 MEMORY.md，什么移到 mem0
- 目标：每个 agent 的 MEMORY.md 控制在 30 行以内，token 节省 60~80%

### mem0-memory SKILL.md
在「强制召回场景」表格里新增第一行：
- **Session start (first message)**：任何 session 的第一条消息都触发召回，提取 2-3 个关键词搜索 mem0

### 关联 Issue
- Closes #93 中的「MEMORY.md 瘦身 + 按需召回」子任务