### PR TITLE
feat: add procedural category, distinguish how-to guides from incident experience (#99)

### DIFF
--- a/docs/guide/best-practices.md
+++ b/docs/guide/best-practices.md
@@ -228,7 +228,10 @@ Only inject results with score >= 0.3. Skip the search entirely if the user's re
 |-----------|-------------|---------|
 | Bug fixed, pitfall found | `experience` (shared) | `--metadata '{"category":"experience"}'` |
 | Technical decision made | `experience` (shared) | `--metadata '{"category":"experience"}'` |
+| Discovered the correct way to use a tool/workflow | `procedural` (shared) | `--metadata '{"category":"procedural"}'` |
 | Project status changed | `project` (agent-specific) | `--metadata '{"category":"project"}'` |
 | Config/env info discovered | `environment` | `--metadata '{"category":"environment"}'` |
 | Today's discussion notes | `short_term` | `--run YYYY-MM-DD --metadata '{"category":"short_term"}'` |
 | User preference observed | `preference` | `--metadata '{"category":"preference"}'` |
+
+> **`experience` vs `procedural`**: `experience` = "what happened + how it was resolved" (incident-driven). `procedural` = "how to do X correctly" (reusable step-by-step guidance). When in doubt: if it reads like a post-mortem → `experience`; if it reads like a how-to guide → `procedural`.

--- a/docs/zh/guide/best-practices.md
+++ b/docs/zh/guide/best-practices.md
@@ -226,7 +226,10 @@ python3 /path/to/mem0-memory-service/cli.py search \
 |------|---------|------|
 | 修复 bug、发现踩坑 | `experience`（共享） | `--metadata '{"category":"experience"}'` |
 | 做了技术决策 | `experience`（共享） | `--metadata '{"category":"experience"}'` |
+| 发现了工具/工作流的正确用法 | `procedural`（共享） | `--metadata '{"category":"procedural"}'` |
 | 项目状态变更 | `project`（agent 专属） | `--metadata '{"category":"project"}'` |
 | 发现配置/环境信息 | `environment` | `--metadata '{"category":"environment"}'` |
 | 今天的讨论记录 | `short_term` | `--run YYYY-MM-DD --metadata '{"category":"short_term"}'` |
 | 观察到用户偏好 | `preference` | `--metadata '{"category":"preference"}'` |
+
+> **`experience` vs `procedural` 的区别**：`experience` = "发生了什么 + 怎么解决的"（事后复盘型）。`procedural` = "如何正确做某件事"（可复用的操作指南）。判断方法：读起来像事故复盘 → `experience`；读起来像操作手册 → `procedural`。


### PR DESCRIPTION
新增 `procedural` category，将可复用的操作步骤/工具用法指南从 `experience` 中分离出来。

**改动：**
- best-practices.md（英文 + 中文）：快速参考表增加 procedural 行 + experience vs procedural 判断说明

**区别：**
- `experience` = 发生了什么+怎么解决（事后复盘型）
- `procedural` = 如何正确做某件事（可复用操作指南）

Closes #99