### PR TITLE
feat: add Step 3 long-term memory consolidation to auto_dream (#101)

### DIFF
--- a/pipelines/auto_dream.py
+++ b/pipelines/auto_dream.py
@@ -288,7 +288,10 @@ def consolidate_longterm_memories(agent_id: str) -> int:
                 "top_k": 3, "time_decay": False
             }, timeout=30)
             sr.raise_for_status()
-            hits = sr.json().get("results", [])
+            sr_data = sr.json()
+            hits = sr_data.get("results", {})
+            if isinstance(hits, dict):
+                hits = hits.get("results", [])
         except Exception as e:
             logger.warning(f"[{agent_id}] Search failed for {mid}: {e}")
             continue


### PR DESCRIPTION
## What

Add **Step 3: Long-term Memory Consolidation** to `auto_dream.py`.

After Step 1 (diary digest) and Step 2 (short-term promotion), Step 3 scans existing long-term memories to find and merge semantically redundant pairs.

## How it works

1. **Batch rotation** — Each run processes `CONSOLIDATION_BATCH=50` memories starting from a persisted offset (per agent). Offset resets to 0 when it exceeds total count, ensuring full coverage over multiple nightly runs.

2. **Candidate pair identification** — For each memory in the batch, calls `POST /memory/search` (top_k=3, time_decay=false). If the top result (excluding self) has `score > 0.85`, the pair is flagged as a candidate. Already-paired IDs are skipped to avoid A↔B duplication.

3. **LLM merge via mem0** — Candidate pairs are combined and sent to `POST /memory/add` with `infer=True`. If mem0 returns ADD or UPDATE, both originals are deleted. If NONE, the pair is skipped (mem0 decided they're distinct).

## Safety

- Step 3 is **non-fatal**: exceptions only log warnings, never abort the pipeline
- No new dependencies — reuses existing `requests`-based API calls
- Offset state stored in `auto_dream_consolidation_offset.json`
