### PR TITLE
feat: add Auto badge for auto-generated memories in UI

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -66,6 +66,7 @@ select:focus,input:focus{border-color:#3b82f6}
             <span class="badge bg-blue-900 text-blue-300">{{m.agent_id||'—'}}</span>
             <span v-if="m.score" class="badge bg-green-900 text-green-300">{{(m.score*100).toFixed(0)}}%</span>
             <span class="badge" :style="isShortTerm(m)?'background:#7c2d12;color:#fdba74':'background:#581c87;color:#d8b4fe'">{{isShortTerm(m)?'短期':'长期'}}</span>
+            <span v-if="isAuto(m)" class="badge" style="background:#14532d;color:#86efac">Auto</span>
             <span class="text-xs text-gray-500">{{fmtTime(m.created_at||m.updated_at)}}</span>
           </div>
           <div :class="expanded===m.id?'':'truncate-2'" class="text-sm text-gray-300 break-words">{{m.memory}}</div>
@@ -177,6 +178,7 @@ createApp({
       page.value=1;loadList()
     }
     function isShortTerm(m){return !!(m.run_id||(m.metadata&&m.metadata.category==='short_term'))}
+    function isAuto(m){const src=(m.metadata&&m.metadata.source)||'';return src.startsWith('auto_')}
 
     onMounted(()=>{loadStats();loadList()})
 


### PR DESCRIPTION
在记忆列表中为自动生成的记忆（source 以 `auto_` 开头）显示绿色 **Auto** 标签。

覆盖的 source 类型：
- `auto_digest`（auto_digest pipeline）
- `auto_dream_digest`（auto_dream Step 1）
- `auto_dream_consolidated`（auto_dream Step 2）
- `auto_dream_consolidation`（auto_dream Step 3）

手动写入（无 source）不显示标签。