### PR TITLE
fix: Memory UI 和 CLI 搜索质量修复

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -184,10 +184,10 @@ def main():
     p_search.add_argument("--query", required=True)
     p_search.add_argument("--top-k", type=int, default=5,
                           help="Max results to return (default: 5)")
-    p_search.add_argument("--min-score", type=float, default=0.0,
+    p_search.add_argument("--min-score", type=float, default=0.5,
                           help="Minimum relevance score to include (0.0–1.0). "
                                "Results below this threshold are dropped. "
-                               "Recommended: 0.3–0.5 to filter low-relevance noise.")
+                               "Default: 0.5 (filters low-relevance noise).")
     p_search.add_argument("--combined", action="store_true",
                           help="Combined search: long-term + recent short-term memories")
     p_search.add_argument("--recent-days", type=int, default=3,

--- a/static/index.html
+++ b/static/index.html
@@ -135,7 +135,7 @@ createApp({
       loading.value=true
       try{
         if(isSearchMode.value&&searchQuery.value){
-          const body={query:searchQuery.value,user_id:USER_ID,top_k:100}
+          const body={query:searchQuery.value,user_id:USER_ID,top_k:10,min_score:0.5}
           if(agentFilter.value)body.agent_id=agentFilter.value
           const r=await fetch(`${API}/memory/search`,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(body)})
           const d=await r.json()


### PR DESCRIPTION
## 问题

Memory UI 搜索框返回不相关结果（如搜"kiro 又出现问题了"，第一条却是"mem0 get_all() 默认 limit=100"）。

## 根因

两个叠加问题：

1. **`top_k=100` 太大**：向量数据库 ANN 近似索引在 limit 很大时精度下降，大量不相关结果混入
2. **无 `min_score` 过滤**：低分结果也展示，CLI 同样 `min_score=0.0`，agent 召回时低相关噪音进入上下文

## 修复

### Memory UI (`static/index.html`)
```js
// 修改前
const body = {query, user_id, top_k: 100}
// 修改后
const body = {query, user_id, top_k: 10, min_score: 0.5}
```

### CLI (`cli.py`)
```
# 修改前：--min-score 默认 0.0
# 修改后：--min-score 默认 0.5
```

## 验证

- 修复前：搜索 "kiro 又出现问题了"，第一条 score=0.97 但内容关于 mem0 分类，完全不相关
- 修复后：返回结果均为 kiro 相关内容，score 合理分布
