### PR TITLE
feat: auto_digest 增加任务记忆专项抽取（category=task）

### DIFF
--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -31,8 +31,20 @@ python3 cli.py add --user me --agent dev --run 2026-03-23 \
 | `--text` | ✅* | Raw text to memorize |
 | `--messages` | ✅* | JSON array of `{role, content}` messages |
 | `--metadata` | | JSON object of metadata tags |
+| `--custom-prompt` | | Custom extraction prompt (overrides default when `infer=true`) |
 
 \* Either `--text` or `--messages` is required.
+
+**Targeted extraction example:**
+
+```bash
+# Extract completed tasks from a session block
+python3 cli.py add --user boss --agent dev \
+  --run 2026-04-11 \
+  --text "<session block content>" \
+  --metadata '{"category":"task"}' \
+  --custom-prompt "从以下对话中列出agent实际完成的工作任务（最终成果），每行一条，格式：[类型] 描述。只写最终成果，不超过5条。"
+```
 
 ### `search` — Semantic Search
 

--- a/docs/api/server.md
+++ b/docs/api/server.md
@@ -55,6 +55,8 @@ curl -X POST http://127.0.0.1:8230/memory/add \
 | `text` | string | ✅* | Raw text to memorize |
 | `messages` | array | ✅* | Conversation messages `[{role, content}]` |
 | `metadata` | object | | Extra metadata tags |
+| `infer` | boolean | | Whether mem0 should extract facts (default: `true`). Set `false` to store raw text as-is. |
+| `custom_extraction_prompt` | string | | Custom prompt to guide fact extraction. Overrides default prompt when `infer=true`. See [Targeted Extraction](#targeted-extraction). |
 
 \* Either `text` or `messages` is required.
 
@@ -75,6 +77,47 @@ curl -X POST http://127.0.0.1:8230/memory/add \
 ::: tip
 Token usage is also written to the audit log (`audit_logs/audit-YYYY-MM-DD.jsonl`) as `type=token_usage` entries, enabling daily cost analysis.
 :::
+
+
+## Targeted Extraction
+
+By default mem0 uses a generic fact-extraction prompt. Pass `custom_extraction_prompt` to guide extraction toward a specific dimension without changing global config.
+
+```bash
+# Extract completed work tasks from a session block
+curl -X POST http://127.0.0.1:8230/memory/add \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "user_id": "boss",
+    "agent_id": "dev",
+    "run_id": "2026-04-11",
+    "text": "<session block content>",
+    "infer": true,
+    "metadata": {"category": "task"},
+    "custom_extraction_prompt": "从以下对话中列出agent实际完成的工作任务（最终成果），每行一条，格式：[类型] 描述。类型：开发/修复/文档/配置/分析/部署/其他。只写最终成果，不超过5条。"
+  }'
+
+# Extract technical decisions
+curl -X POST http://127.0.0.1:8230/memory/add \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "user_id": "boss",
+    "agent_id": "dev",
+    "text": "<session block>",
+    "metadata": {"category": "decision"},
+    "custom_extraction_prompt": "从以下对话中提取重要技术决策及原因，每条一行，格式：[决策] 原因。"
+  }'
+```
+
+**When to use:**
+| Situation | Recommended `custom_extraction_prompt` |
+|-----------|----------------------------------------|
+| Work task summary | `"列出agent实际完成的工作任务（最终成果），格式：[类型] 描述..."` |
+| Technical decisions | `"提取重要技术决策及原因，格式：[决策] 原因..."` |
+| Config/env discovery | `"提取新增的服务配置、端口、路径等环境信息..."` |
+| Default (omit) | mem0 uses generic extraction — good for mixed content |
+
+> **Note:** `custom_extraction_prompt` only affects this single call. It does not change the global mem0 configuration.
 
 ## Search
 

--- a/docs/guide/best-practices.md
+++ b/docs/guide/best-practices.md
@@ -233,5 +233,39 @@ Only inject results with score >= 0.3. Skip the search entirely if the user's re
 | Config/env info discovered | `environment` | `--metadata '{"category":"environment"}'` |
 | Today's discussion notes | `short_term` | `--run YYYY-MM-DD --metadata '{"category":"short_term"}'` |
 | User preference observed | `preference` | `--metadata '{"category":"preference"}'` |
+| Completed work tasks (auto_digest) | `task` | `--metadata '{"category":"task"}' --custom-prompt "..."` |
 
 > **`experience` vs `procedural`**: `experience` = "what happened + how it was resolved" (incident-driven). `procedural` = "how to do X correctly" (reusable step-by-step guidance). When in doubt: if it reads like a post-mortem → `experience`; if it reads like a how-to guide → `procedural`.
+
+## Targeted Memory Extraction with `custom_extraction_prompt`
+
+By default, `auto_digest` and direct `add` calls use mem0's generic fact-extraction prompt, which may produce mixed results (preferences, configs, code snippets). Use `custom_extraction_prompt` to extract along a specific dimension.
+
+### When to use
+
+| Goal | Prompt hint |
+|------|------------|
+| Work task summary | `"列出agent实际完成的工作任务（最终成果），格式：[类型] 描述..."` |
+| Technical decisions | `"提取重要技术决策及原因，格式：[决策] 原因..."` |
+| Config/env discovery | `"提取新增的服务配置、端口、路径等环境信息..."` |
+| Default | Omit — mem0 uses generic extraction |
+
+### How it works
+
+```
+POST /memory/add
+  text: <session block>
+  infer: true
+  metadata: {category: "task"}
+  custom_extraction_prompt: "..."   ← overrides default prompt for this call only
+```
+
+The `custom_extraction_prompt` is passed directly to mem0's `Memory.add(prompt=...)` — it is scoped to the single call and does not change global config.
+
+### auto_digest integration
+
+`auto_digest.py` automatically runs targeted task extraction on every session block:
+1. **Pass ①** — generic `infer=True` → `category=short_term`
+2. **Pass ②** — `custom_extraction_prompt` (task-focused) → `category=task`
+
+This makes work task recall much more precise: query `"最近完成的任务"` returns clean `[类型] 描述` entries instead of scattered facts.

--- a/docs/zh/api/cli.md
+++ b/docs/zh/api/cli.md
@@ -31,8 +31,20 @@ python3 cli.py add --user me --agent dev --run 2026-03-23 \
 | `--text` | ✅* | 要记忆的原始文本 |
 | `--messages` | ✅* | `{role, content}` 消息的 JSON 数组 |
 | `--metadata` | | 元数据标签的 JSON 对象 |
+| `--custom-prompt` | | 自定义提炼提示词（`infer=true` 时覆盖默认 prompt） |
 
 \* `--text` 或 `--messages` 二选一，必须提供其一。
+
+**定向抽取示例：**
+
+```bash
+# 从 session block 抽取已完成工作任务
+python3 cli.py add --user boss --agent dev \
+  --run 2026-04-11 \
+  --text "<session block 内容>" \
+  --metadata '{"category":"task"}' \
+  --custom-prompt "从以下对话中列出agent实际完成的工作任务（最终成果），每行一条，格式：[类型] 描述。只写最终成果，不超过5条。"
+```
 
 ### `search` — 语义搜索
 

--- a/docs/zh/api/server.md
+++ b/docs/zh/api/server.md
@@ -55,8 +55,41 @@ curl -X POST http://127.0.0.1:8230/memory/add \
 | `text` | string | ✅* | 要记忆的原始文本 |
 | `messages` | array | ✅* | 对话消息 `[{role, content}]` |
 | `metadata` | object | | 额外元数据标签 |
+| `infer` | boolean | | 是否让 mem0 提炼事实（默认 `true`）。设为 `false` 则原文存储。 |
+| `custom_extraction_prompt` | string | | 自定义提炼提示词，覆盖默认 prompt（仅在 `infer=true` 时生效）。详见[定向记忆抽取](#定向记忆抽取)。 |
 
 \* `text` 或 `messages` 二选一，必须提供其一。
+
+
+## 定向记忆抽取
+
+默认情况下，mem0 使用通用的事实提炼 prompt。通过 `custom_extraction_prompt` 可以指定特定维度进行抽取，无需修改全局配置。
+
+```bash
+# 从 session block 抽取已完成工作任务
+curl -X POST http://127.0.0.1:8230/memory/add \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "user_id": "boss",
+    "agent_id": "dev",
+    "run_id": "2026-04-11",
+    "text": "<session block 内容>",
+    "infer": true,
+    "metadata": {"category": "task"},
+    "custom_extraction_prompt": "从以下对话中列出agent实际完成的工作任务（最终成果），每行一条，格式：[类型] 描述。类型：开发/修复/文档/配置/分析/部署/其他。只写最终成果，不超过5条。"
+  }'
+```
+
+**使用场景：**
+
+| 场景 | 推荐 `custom_extraction_prompt` |
+|------|--------------------------------|
+| 工作任务汇总 | `"列出agent实际完成的工作任务（最终成果），格式：[类型] 描述..."` |
+| 技术决策记录 | `"提取重要技术决策及原因，格式：[决策] 原因..."` |
+| 配置/环境发现 | `"提取新增的服务配置、端口、路径等环境信息..."` |
+| 默认（不传） | mem0 使用通用提炼，适合混合内容 |
+
+> **注意：** `custom_extraction_prompt` 仅对当次调用生效，不影响全局 mem0 配置。
 
 ## 搜索
 

--- a/docs/zh/guide/best-practices.md
+++ b/docs/zh/guide/best-practices.md
@@ -231,5 +231,37 @@ python3 /path/to/mem0-memory-service/cli.py search \
 | 发现配置/环境信息 | `environment` | `--metadata '{"category":"environment"}'` |
 | 今天的讨论记录 | `short_term` | `--run YYYY-MM-DD --metadata '{"category":"short_term"}'` |
 | 观察到用户偏好 | `preference` | `--metadata '{"category":"preference"}'` |
+| 已完成工作任务（auto_digest 自动） | `task` | `--metadata '{"category":"task"}' --custom-prompt "..."` |
 
 > **`experience` vs `procedural` 的区别**：`experience` = "发生了什么 + 怎么解决的"（事后复盘型）。`procedural` = "如何正确做某件事"（可复用的操作指南）。判断方法：读起来像事故复盘 → `experience`；读起来像操作手册 → `procedural`。
+
+## 定向记忆抽取（`custom_extraction_prompt`）
+
+默认情况下，`auto_digest` 和直接 `add` 调用使用 mem0 的通用提炼 prompt，结果可能混杂偏好、配置、代码片段等。通过 `custom_extraction_prompt` 可针对特定维度进行精准抽取。
+
+### 使用场景
+
+| 目标 | Prompt 方向 |
+|------|------------|
+| 工作任务汇总 | `"列出agent实际完成的工作任务（最终成果），格式：[类型] 描述..."` |
+| 技术决策记录 | `"提取重要技术决策及原因，格式：[决策] 原因..."` |
+| 配置/环境发现 | `"提取新增的服务配置、端口、路径等环境信息..."` |
+| 默认（不传） | mem0 使用通用提炼，适合混合内容 |
+
+### 工作原理
+
+```
+POST /memory/add
+  text: <session block>
+  infer: true
+  metadata: {category: "task"}
+  custom_extraction_prompt: "..."   ← 仅对此次调用生效，不影响全局配置
+```
+
+### auto_digest 集成
+
+`auto_digest.py` 对每个 session block 自动执行两轮抽取：
+1. **第①轮** — 通用 `infer=True` → `category=short_term`（通用事实）
+2. **第②轮** — `custom_extraction_prompt`（任务维度）→ `category=task`（已完成任务）
+
+这样后续执行"最近做了哪些工作"类查询时，可以精准召回 `[类型] 描述` 格式的任务条目，而不是散碎的事实片段。

--- a/pipelines/auto_digest.py
+++ b/pipelines/auto_digest.py
@@ -15,7 +15,6 @@ import sys
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
-import boto3
 import requests
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
@@ -40,8 +39,6 @@ BATCH_SLEEP_SECS = 5      # 批次间 sleep，避免打爆 mem0
 
 # ─── Task Extraction ───
 TASK_EXTRACTION_ENABLED = os.environ.get("DIGEST_TASK_EXTRACTION", "true").lower() == "true"
-TASK_EXTRACTION_MODEL = os.environ.get("DIGEST_TASK_MODEL", "us.anthropic.claude-haiku-4-5-20251001-v1:0")
-AWS_REGION = os.environ.get("AWS_REGION", "us-east-1")
 
 # ─── Setup Logging ───
 
@@ -187,83 +184,46 @@ def write_to_mem0(event: str, run_id: str, agent_id: str, incremental: bool = Fa
 
 
 
-def extract_tasks_from_block(block: str, agent_id: str) -> list[str]:
-    """用 LLM 从 session block 中抽取 agent 完成的工作任务。
-    返回任务描述列表，每条是一句简洁的完成记录。
-    如果没有明显任务或调用失败，返回空列表。
+TASK_EXTRACTION_PROMPT = (
+    "从以下对话日记中列出agent实际完成的工作任务（最终成果），每行一条，"
+    "格式：[类型] 描述。类型：开发/修复/文档/配置/分析/部署/其他。"
+    "要求：只写最终成果不写步骤，不超过5条，每条不超过60字，没有任务只写'无'，直接输出列表不要分析。"
+)
+
+
+def extract_and_write_task_memories(block: str, run_id: str, agent_id: str) -> int:
+    """通过 /memory/add + custom_extraction_prompt 提炼并写入任务记忆（category=task）。
+    返回成功写入数量（0 表示无任务或失败）。
     """
     if not TASK_EXTRACTION_ENABLED:
-        return []
-    task_prompt = (
-        "从以下对话日记中列出agent实际完成的工作任务（最终成果），每行一条，"
-        "格式：[类型] 描述。类型：开发/修复/文档/配置/分析/部署/其他。"
-        "要求：只写最终成果不写步骤，不超过5条，每条不超过60字，没有任务只写'无'，直接输出列表不要分析。"
-    )
-    prompt = task_prompt + "\n\n" + block[:3000]
-
+        return 0
     try:
-        bedrock = boto3.client("bedrock-runtime", region_name=AWS_REGION)
-        body = json.dumps({
-            "anthropic_version": "bedrock-2023-05-31",
-            "messages": [{"role": "user", "content": prompt}],
-            "max_tokens": 512,
-            "temperature": 0.0,
-        })
-        resp = bedrock.invoke_model(
-            modelId=TASK_EXTRACTION_MODEL,
-            body=body,
-            contentType="application/json",
-            accept="application/json",
-        )
-        result = json.loads(resp["body"].read())
-        text = (result.get("content") or [{}])[0].get("text", "").strip()
-
-        if not text or text == "无" or text.startswith("无"):
-            return []
-
-        tasks = []
-        for line in text.splitlines():
-            line = line.strip()
-            if not line or line == "无":
-                continue
-            # 去掉 <reasoning>...</reasoning> 标签内容
-            if line.startswith("<") or line.startswith(">"):
-                continue
-            # 去掉序号
-            line = re.sub(r'^\d+[.\)]\.?\s*', '', line).strip()
-            if line:
-                tasks.append(line)
-        return tasks[:10]  # 最多10条，防止 LLM 发散
+        metadata = {
+            "category": "task",
+            "source": "auto_digest_task",
+            "digest_date": run_id,
+            "workspace_agent": agent_id,
+        }
+        resp = requests.post(MEM0_API_URL, json={
+            "user_id": "boss",
+            "agent_id": agent_id,
+            "run_id": run_id,
+            "text": block[:3000],
+            "infer": True,
+            "metadata": metadata,
+            "custom_extraction_prompt": TASK_EXTRACTION_PROMPT,
+        }, timeout=120)
+        resp.raise_for_status()
+        result = resp.json().get("result", {})
+        written = len([r for r in result.get("results", []) if r.get("event") in ("ADD", "UPDATE")])
+        if written:
+            logger.info(f"[{agent_id}] ✓ Task extraction: {written} task memories written")
+        else:
+            logger.debug(f"[{agent_id}] Task extraction: no new tasks from this block")
+        return written
     except Exception as e:
         logger.warning(f"[{agent_id}] Task extraction failed: {e}")
-        return []
-
-
-def write_task_memories(tasks: list[str], run_id: str, agent_id: str) -> int:
-    """将抽取的任务列表写入 mem0（category=task）。返回成功写入数量。"""
-    success = 0
-    for task in tasks:
-        try:
-            metadata = {
-                "category": "task",
-                "source": "auto_digest_task",
-                "digest_date": run_id,
-                "workspace_agent": agent_id
-            }
-            resp = requests.post(MEM0_API_URL, json={
-                "user_id": "boss",
-                "agent_id": agent_id,
-                "run_id": run_id,
-                "text": task,
-                "infer": False,  # 任务已经是精炼文本，不需要再 infer
-                "metadata": metadata
-            }, timeout=60)
-            resp.raise_for_status()
-            logger.info(f"[{agent_id}] ✓ Task memory: {task[:80]}")
-            success += 1
-        except Exception as e:
-            logger.warning(f"[{agent_id}] Failed to write task memory: {task[:60]} | {e}")
-    return success
+        return 0
 
 
 def split_into_session_blocks(content: str) -> list[str]:
@@ -369,11 +329,8 @@ def process_agent(agent_id: str, workspace: Path, date: str, incremental: bool =
                     cumulative_bytes += block_bytes
                     agent_offsets[date] = prev_offset + cumulative_bytes
                     save_offsets(offsets)
-                    # 任务专项抽取（异步写入，失败不阻塞主流程）
-                    tasks = extract_tasks_from_block(block, agent_id)
-                    if tasks:
-                        written = write_task_memories(tasks, date, agent_id)
-                        logger.info(f"[{agent_id}] Block {i+1}: extracted {len(tasks)} tasks, wrote {written}")
+                    # 任务专项抽取（通过 custom_extraction_prompt，失败不阻塞主流程）
+                    extract_and_write_task_memories(block, date, agent_id)
                 else:
                     batches_failed += 1
                     logger.warning(f"[{agent_id}] Block {i+1} failed, stopping to retry next run")
@@ -407,11 +364,8 @@ def process_agent(agent_id: str, workspace: Path, date: str, incremental: bool =
             if block.strip():
                 if write_to_mem0(block, date, agent_id, incremental=False):
                     batches_sent += 1
-                    # 任务专项抽取
-                    tasks = extract_tasks_from_block(block, agent_id)
-                    if tasks:
-                        written = write_task_memories(tasks, date, agent_id)
-                        logger.info(f"[{agent_id}] Block {i+1}: extracted {len(tasks)} tasks, wrote {written}")
+                    # 任务专项抽取（通过 custom_extraction_prompt）
+                    extract_and_write_task_memories(block, date, agent_id)
                 else:
                     batches_failed += 1
             if i < len(blocks) - 1:

--- a/pipelines/auto_digest.py
+++ b/pipelines/auto_digest.py
@@ -15,6 +15,7 @@ import sys
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
+import boto3
 import requests
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
@@ -36,6 +37,11 @@ MIN_CONTENT_BYTES = 5000   # 新增内容少于此值则跳过（避免无意义
 MAX_BLOCK_BYTES = 100 * 1024  # Max bytes per session block before sub-splitting (100KB)
 BATCH_SIZE_BYTES = MAX_BLOCK_BYTES  # Legacy alias — only used as fallback for oversized blocks
 BATCH_SLEEP_SECS = 5      # 批次间 sleep，避免打爆 mem0
+
+# ─── Task Extraction ───
+TASK_EXTRACTION_ENABLED = os.environ.get("DIGEST_TASK_EXTRACTION", "true").lower() == "true"
+TASK_EXTRACTION_MODEL = os.environ.get("DIGEST_TASK_MODEL", "us.anthropic.claude-haiku-4-5-20251001-v1:0")
+AWS_REGION = os.environ.get("AWS_REGION", "us-east-1")
 
 # ─── Setup Logging ───
 
@@ -181,6 +187,85 @@ def write_to_mem0(event: str, run_id: str, agent_id: str, incremental: bool = Fa
 
 
 
+def extract_tasks_from_block(block: str, agent_id: str) -> list[str]:
+    """用 LLM 从 session block 中抽取 agent 完成的工作任务。
+    返回任务描述列表，每条是一句简洁的完成记录。
+    如果没有明显任务或调用失败，返回空列表。
+    """
+    if not TASK_EXTRACTION_ENABLED:
+        return []
+    task_prompt = (
+        "从以下对话日记中列出agent实际完成的工作任务（最终成果），每行一条，"
+        "格式：[类型] 描述。类型：开发/修复/文档/配置/分析/部署/其他。"
+        "要求：只写最终成果不写步骤，不超过5条，每条不超过60字，没有任务只写'无'，直接输出列表不要分析。"
+    )
+    prompt = task_prompt + "\n\n" + block[:3000]
+
+    try:
+        bedrock = boto3.client("bedrock-runtime", region_name=AWS_REGION)
+        body = json.dumps({
+            "anthropic_version": "bedrock-2023-05-31",
+            "messages": [{"role": "user", "content": prompt}],
+            "max_tokens": 512,
+            "temperature": 0.0,
+        })
+        resp = bedrock.invoke_model(
+            modelId=TASK_EXTRACTION_MODEL,
+            body=body,
+            contentType="application/json",
+            accept="application/json",
+        )
+        result = json.loads(resp["body"].read())
+        text = (result.get("content") or [{}])[0].get("text", "").strip()
+
+        if not text or text == "无" or text.startswith("无"):
+            return []
+
+        tasks = []
+        for line in text.splitlines():
+            line = line.strip()
+            if not line or line == "无":
+                continue
+            # 去掉 <reasoning>...</reasoning> 标签内容
+            if line.startswith("<") or line.startswith(">"):
+                continue
+            # 去掉序号
+            line = re.sub(r'^\d+[.\)]\.?\s*', '', line).strip()
+            if line:
+                tasks.append(line)
+        return tasks[:10]  # 最多10条，防止 LLM 发散
+    except Exception as e:
+        logger.warning(f"[{agent_id}] Task extraction failed: {e}")
+        return []
+
+
+def write_task_memories(tasks: list[str], run_id: str, agent_id: str) -> int:
+    """将抽取的任务列表写入 mem0（category=task）。返回成功写入数量。"""
+    success = 0
+    for task in tasks:
+        try:
+            metadata = {
+                "category": "task",
+                "source": "auto_digest_task",
+                "digest_date": run_id,
+                "workspace_agent": agent_id
+            }
+            resp = requests.post(MEM0_API_URL, json={
+                "user_id": "boss",
+                "agent_id": agent_id,
+                "run_id": run_id,
+                "text": task,
+                "infer": False,  # 任务已经是精炼文本，不需要再 infer
+                "metadata": metadata
+            }, timeout=60)
+            resp.raise_for_status()
+            logger.info(f"[{agent_id}] ✓ Task memory: {task[:80]}")
+            success += 1
+        except Exception as e:
+            logger.warning(f"[{agent_id}] Failed to write task memory: {task[:60]} | {e}")
+    return success
+
+
 def split_into_session_blocks(content: str) -> list[str]:
     """Split diary content by '### [HH:MM]' session time markers.
 
@@ -284,6 +369,11 @@ def process_agent(agent_id: str, workspace: Path, date: str, incremental: bool =
                     cumulative_bytes += block_bytes
                     agent_offsets[date] = prev_offset + cumulative_bytes
                     save_offsets(offsets)
+                    # 任务专项抽取（异步写入，失败不阻塞主流程）
+                    tasks = extract_tasks_from_block(block, agent_id)
+                    if tasks:
+                        written = write_task_memories(tasks, date, agent_id)
+                        logger.info(f"[{agent_id}] Block {i+1}: extracted {len(tasks)} tasks, wrote {written}")
                 else:
                     batches_failed += 1
                     logger.warning(f"[{agent_id}] Block {i+1} failed, stopping to retry next run")
@@ -317,6 +407,11 @@ def process_agent(agent_id: str, workspace: Path, date: str, incremental: bool =
             if block.strip():
                 if write_to_mem0(block, date, agent_id, incremental=False):
                     batches_sent += 1
+                    # 任务专项抽取
+                    tasks = extract_tasks_from_block(block, agent_id)
+                    if tasks:
+                        written = write_task_memories(tasks, date, agent_id)
+                        logger.info(f"[{agent_id}] Block {i+1}: extracted {len(tasks)} tasks, wrote {written}")
                 else:
                     batches_failed += 1
             if i < len(blocks) - 1:


### PR DESCRIPTION
Closes #130

## 变更内容

在 `auto_digest.py` 每个 session block 写入 mem0 后，额外调用 LLM 做任务抽取 pass：

- 用 Claude Haiku 从 session block 提炼 agent 实际完成的工作任务
- 每条任务格式：`[类型] 描述`，类型包括开发/修复/文档/配置/分析/部署/其他
- 写入 mem0 时使用 `category=task`，`infer=False`（已是精炼文本，不需要再 infer）
- 通过 `DIGEST_TASK_EXTRACTION=false` 环境变量可关闭（默认开启）
- 通过 `DIGEST_TASK_MODEL` 可自定义模型（默认 `us.anthropic.claude-haiku-4-5-20251001-v1:0`）

## 效果示例

输入 session block 后，抽取结果：
```
[开发] 编写embedding模型迁移脚本，将模型切换为cohere multilingual-v3，PR #129已提交
[配置] 更新.env配置文件，切换embedding模型为cohere.embed-multilingual-v3
[部署] 更新本地Docker容器，确认新embedding模型正常运行
```

## 优势

- 下次工作回顾时，可以直接用 `query="最近完成的任务"` 精准召回
- task 记忆独立于 short_term，不受时间衰减干扰
- 粒度适合汇报：不是步骤，是成果