### PR TITLE
feat: /memory/add 支持 custom_extraction_prompt，灵活控制记忆抽取维度

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -39,6 +39,9 @@ def add_memory(args):
         print("Error: --text or --messages required", file=sys.stderr)
         sys.exit(1)
 
+    if getattr(args, "custom_prompt", None):
+        payload["custom_extraction_prompt"] = args.custom_prompt
+
     resp = requests.post(f"{BASE_URL}/memory/add", json=payload, timeout=60)
     resp.raise_for_status()
     result = resp.json()
@@ -174,6 +177,7 @@ def main():
     p_add.add_argument("--text", default=None)
     p_add.add_argument("--messages", default=None, help="JSON array of {role, content}")
     p_add.add_argument("--metadata", default=None, help="JSON object of metadata")
+    p_add.add_argument("--custom-prompt", default=None, dest="custom_prompt", help="Custom extraction prompt to guide mem0 fact extraction (overrides default, only when infer=True)")
     p_add.set_defaults(func=add_memory)
 
     # search

--- a/server.py
+++ b/server.py
@@ -154,6 +154,7 @@ class AddMemoryRequest(BaseModel):
     run_id: Optional[str] = Field(None, description="Run/session identifier (e.g. YYYY-MM-DD for short-term memories)")
     metadata: Optional[Dict[str, Any]] = Field(None, description="Extra metadata tags")
     infer: bool = Field(True, description="Whether mem0 should infer/extract facts (True) or store raw text (False)")
+    custom_extraction_prompt: Optional[str] = Field(None, description="Custom prompt to guide mem0 fact extraction (overrides default). Only effective when infer=True.")
 
 
 class SearchMemoryRequest(BaseModel):
@@ -230,10 +231,13 @@ async def add_memory(req: AddMemoryRequest):
 
             def _add_with_tracking():
                 reset_token_counter()
+                add_extra = {}
+                if req.custom_extraction_prompt:
+                    add_extra["prompt"] = req.custom_extraction_prompt
                 if req.messages:
-                    result = memory.add(req.messages, infer=infer, **kwargs)
+                    result = memory.add(req.messages, infer=infer, **kwargs, **add_extra)
                 else:
-                    result = memory.add(req.text, infer=infer, **kwargs)
+                    result = memory.add(req.text, infer=infer, **kwargs, **add_extra)
                 return result, get_token_stats()
 
             result, token_stats = await loop.run_in_executor(_mem0_executor, _add_with_tracking)


### PR DESCRIPTION
Closes #132

## 变更内容

### server.py
- `AddMemoryRequest` 新增可选字段 `custom_extraction_prompt`
- 当传入时，透传给 mem0 `Memory.add()` 的 `prompt` 参数（mem0 原生支持），覆盖默认 fact extraction prompt

### cli.py
- `add` 命令新增 `--custom-prompt` 参数

### mem0-memory SKILL.md
- 新增 `--custom-prompt` 使用示例和场景说明

## 使用示例

```bash
# 任务维度抽取
mem0.sh add --user boss --agent dev \
  --text "<session block>" --run 2026-04-11 \
  --metadata '{"category":"task"}' \
  --custom-prompt "从以下对话中列出agent实际完成的工作任务（最终成果），每行一条，格式：[类型] 描述。"

# 决策维度抽取  
mem0.sh add --user boss --agent dev \
  --text "<session block>" \
  --metadata '{"category":"decision"}' \
  --custom-prompt "从以下对话中提取重要技术决策及原因..."
```

## 实现说明

mem0 的 `Memory.add()` 本身已支持 `prompt` 参数，本 PR 只是在 HTTP API 层透传，零侵入，不影响现有行为（不传时走默认 prompt）。