### PR TITLE
fix: restore retrieval_detail audit log lost in PR #133 merge

### DIFF
--- a/config.py
+++ b/config.py
@@ -58,6 +58,9 @@ LLM_MAX_TOKENS = int(os.getenv("LLM_MAX_TOKENS", "2000"))
 DIGEST_LLM_MODEL = os.getenv("DIGEST_LLM_MODEL", "minimax.minimax-m2.5")
 DIGEST_LLM_REGION = os.getenv("DIGEST_LLM_REGION", AWS_REGION)
 
+# Audit
+AUDIT_LOG_RETRIEVAL_DETAIL = os.getenv("AUDIT_LOG_RETRIEVAL_DETAIL", "false").lower() == "true"
+
 # Service
 SERVICE_HOST = os.getenv("SERVICE_HOST", "0.0.0.0")
 SERVICE_PORT = int(os.getenv("SERVICE_PORT", "8230"))

--- a/server.py
+++ b/server.py
@@ -22,7 +22,7 @@ from pydantic import BaseModel, Field
 os.environ.setdefault("AWS_REGION", "us-east-1")
 
 from mem0 import Memory
-from config import get_mem0_config, replace_llm_with_tracked, SERVICE_HOST, SERVICE_PORT
+from config import get_mem0_config, replace_llm_with_tracked, SERVICE_HOST, SERVICE_PORT, AUDIT_LOG_RETRIEVAL_DETAIL
 from tracked_llm import reset_token_counter, get_token_stats
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
@@ -63,6 +63,29 @@ def cleanup_old_audit_logs():
                 logger.info(f"Deleted old audit log: {f.name}")
         except Exception:
             pass
+
+
+def _write_retrieval_detail_log(
+    path: str, agent_id: Optional[str], user_id: str, query: str, results: list
+):
+    """Write retrieval detail (query + results) to audit log when AUDIT_LOG_RETRIEVAL_DETAIL=true."""
+    detail_entry = {
+        "ts": datetime.now(timezone.utc).isoformat(),
+        "event": "retrieval_detail",
+        "path": path,
+        "agent_id": agent_id or "-",
+        "user_id": user_id,
+        "query": query,
+        "results": [
+            {"id": r.get("id"), "memory": r.get("memory"), "score": r.get("score")}
+            for r in results
+        ],
+    }
+    try:
+        with get_audit_log_path().open("a", encoding="utf-8") as f:
+            f.write(json.dumps(detail_entry, ensure_ascii=False) + "\n")
+    except Exception as e:
+        logger.warning(f"Failed to write retrieval detail audit log: {e}")
 
 
 # ─── Global mem0 instance ───
@@ -366,6 +389,8 @@ async def search_memory(req: SearchMemoryRequest):
             raw = [r for r in raw if r.get("score", 0.0) >= req.min_score]
         if req.time_decay:
             raw = _apply_time_decay(raw)
+        if AUDIT_LOG_RETRIEVAL_DETAIL:
+            _write_retrieval_detail_log("/memory/search", req.agent_id, req.user_id, req.query, raw)
         return {"status": "ok", "results": {"results": raw}}
     except Exception as e:
         logger.error(f"Error searching memory: {e}", exc_info=True)
@@ -466,6 +491,8 @@ async def search_combined(req: CombinedSearchRequest):
     # 4. Merge all layers and return (no cross-layer re-ranking, preserve per-layer scores)
     all_results = long_term_results + short_term_results + shared_results
 
+    if AUDIT_LOG_RETRIEVAL_DETAIL:
+        _write_retrieval_detail_log("/memory/search_combined", req.agent_id, req.user_id, req.query, all_results)
     return {"status": "ok", "results": all_results}
 
 


### PR DESCRIPTION
## 问题

PR #133（custom_extraction_prompt 功能）在合并时存在合并冲突处理不当，将 PR #128 引入的 retrieval_detail 审计日志功能代码完整删除。

## 根因

PR #133 的分支基于 #128 合并之前的代码，合并时没有正确 rebase，导致：
- `config.py` 中的 `AUDIT_LOG_RETRIEVAL_DETAIL` 被删除
- `server.py` 中的 `_write_retrieval_detail_log()` 函数被删除  
- `/memory/search` 和 `/memory/search_combined` 中的调用点被删除

## 修复

完整还原 #128 引入的代码（未改动 #133 的新功能）：
- `config.py`: 恢复 `AUDIT_LOG_RETRIEVAL_DETAIL` env var
- `server.py`: 恢复 `_write_retrieval_detail_log()` helper
- `server.py`: 恢复 `/memory/search` 中的调用
- `server.py`: 恢复 `/memory/search_combined` 中的调用

## 验证

```bash
python3 -c "from config import AUDIT_LOG_RETRIEVAL_DETAIL; print(AUDIT_LOG_RETRIEVAL_DETAIL)"
# True（.env 中已配置 AUDIT_LOG_RETRIEVAL_DETAIL=true）
```

Fixes regression introduced in #133