### PR TITLE
ci: add audit retrieval smoke test to prevent silent regression

### DIFF
--- a/.github/workflows/audit-smoke-test.yml
+++ b/.github/workflows/audit-smoke-test.yml
@@ -1,0 +1,104 @@
+name: Audit Smoke Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  audit-smoke-test:
+    name: Verify retrieval_detail audit logging
+    runs-on: ubuntu-latest
+
+    env:
+      MEM0_SERVICE_URL: http://localhost:8230
+      AUDIT_LOG_DIR: ./audit_logs
+      # Minimal env to boot the service in CI (no real LLM/vector needed for search smoke test)
+      AWS_REGION: us-east-1
+      VECTOR_STORE: pgvector
+      PGVECTOR_HOST: localhost
+      PGVECTOR_PORT: 5432
+      PGVECTOR_DB: mem0
+      PGVECTOR_USER: mem0
+      PGVECTOR_PASSWORD: mem0ci
+      PGVECTOR_COLLECTION: mem0_memories
+      EMBEDDING_MODEL: amazon.titan-embed-text-v2:0
+      EMBEDDING_DIMS: 1024
+      LLM_MODEL: us.anthropic.claude-3-5-haiku-20241022-v1:0
+      LLM_TEMPERATURE: "0.1"
+      LLM_MAX_TOKENS: "2000"
+      SERVICE_HOST: "0.0.0.0"
+      SERVICE_PORT: "8230"
+      AUDIT_LOG_RETRIEVAL_DETAIL: "true"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install test dependencies
+        run: pip install requests pytest
+
+      - name: Create required directories
+        run: mkdir -p audit_logs
+
+      - name: Write CI .env file
+        run: |
+          cat > .env <<EOF
+          AWS_REGION=${AWS_REGION}
+          VECTOR_STORE=${VECTOR_STORE}
+          PGVECTOR_HOST=${PGVECTOR_HOST}
+          PGVECTOR_PORT=${PGVECTOR_PORT}
+          PGVECTOR_DB=${PGVECTOR_DB}
+          PGVECTOR_USER=${PGVECTOR_USER}
+          PGVECTOR_PASSWORD=${PGVECTOR_PASSWORD}
+          PGVECTOR_COLLECTION=${PGVECTOR_COLLECTION}
+          EMBEDDING_MODEL=${EMBEDDING_MODEL}
+          EMBEDDING_DIMS=${EMBEDDING_DIMS}
+          LLM_MODEL=${LLM_MODEL}
+          LLM_TEMPERATURE=${LLM_TEMPERATURE}
+          LLM_MAX_TOKENS=${LLM_MAX_TOKENS}
+          SERVICE_HOST=${SERVICE_HOST}
+          SERVICE_PORT=${SERVICE_PORT}
+          AUDIT_LOG_RETRIEVAL_DETAIL=${AUDIT_LOG_RETRIEVAL_DETAIL}
+          EOF
+
+      - name: Start mem0-api service
+        run: docker compose up -d mem0-api mem0-postgres
+
+      - name: Wait for service health
+        run: |
+          echo "Waiting for mem0-api to be healthy..."
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:8230/health > /dev/null 2>&1; then
+              echo "Service is healthy after ${i}s"
+              break
+            fi
+            if [ "$i" -eq 30 ]; then
+              echo "Service failed to become healthy after 30s"
+              docker compose logs mem0-api
+              exit 1
+            fi
+            sleep 1
+          done
+
+      - name: Run audit smoke tests
+        run: |
+          pytest tests/test_audit_retrieval.py -v
+
+      - name: Show audit log on failure
+        if: failure()
+        run: |
+          echo "=== Audit log contents ==="
+          cat audit_logs/audit-$(date +%Y-%m-%d).jsonl 2>/dev/null || echo "(no audit log found)"
+          echo "=== Docker logs ==="
+          docker compose logs mem0-api
+
+      - name: Cleanup
+        if: always()
+        run: docker compose down -v

--- a/tests/test_audit_retrieval.py
+++ b/tests/test_audit_retrieval.py
@@ -1,0 +1,136 @@
+"""
+Smoke test: verify retrieval_detail audit log entries are written by
+/memory/search and /memory/search_combined.
+
+This test guards against silent regression where the audit logging code
+is accidentally deleted during merges (as happened in PR #133).
+
+Usage:
+    pytest tests/test_audit_retrieval.py -v
+
+Environment variables:
+    MEM0_SERVICE_URL  - service base URL (default: http://localhost:8230)
+    AUDIT_LOG_DIR     - path to audit_logs directory (default: ./audit_logs)
+"""
+
+import json
+import os
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+import requests
+
+SERVICE_URL = os.getenv("MEM0_SERVICE_URL", "http://localhost:8230")
+AUDIT_LOG_DIR = Path(os.getenv("AUDIT_LOG_DIR", "./audit_logs"))
+
+TEST_USER = "ci-smoke-test"
+TEST_AGENT = "ci"
+TEST_QUERY = "smoke test retrieval audit"
+
+
+def get_today_audit_log() -> Path:
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    return AUDIT_LOG_DIR / f"audit-{today}.jsonl"
+
+
+def read_retrieval_detail_entries(path: Path, endpoint: str) -> list[dict]:
+    """Read all retrieval_detail entries for the given endpoint from audit log."""
+    entries = []
+    if not path.exists():
+        return entries
+    with path.open(encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entry = json.loads(line)
+                if entry.get("event") == "retrieval_detail" and entry.get("path") == endpoint:
+                    entries.append(entry)
+            except json.JSONDecodeError:
+                continue
+    return entries
+
+
+def test_service_health():
+    """Service must be up before running audit tests."""
+    resp = requests.get(f"{SERVICE_URL}/health", timeout=10)
+    assert resp.status_code == 200
+    assert resp.json().get("status") == "ok"
+
+
+def test_retrieval_detail_audit_for_search():
+    """
+    /memory/search must write a retrieval_detail entry to the audit log
+    containing all required fields: event, path, query, results, agent_id, user_id.
+    """
+    audit_log = get_today_audit_log()
+    count_before = len(read_retrieval_detail_entries(audit_log, "/memory/search"))
+
+    resp = requests.post(
+        f"{SERVICE_URL}/memory/search",
+        json={"query": TEST_QUERY, "user_id": TEST_USER, "agent_id": TEST_AGENT, "top_k": 3},
+        timeout=30,
+    )
+    assert resp.status_code == 200, f"search returned {resp.status_code}: {resp.text}"
+
+    # Give the service a moment to flush the log (it's synchronous, but be safe)
+    time.sleep(0.5)
+
+    entries_after = read_retrieval_detail_entries(audit_log, "/memory/search")
+    new_entries = entries_after[count_before:]
+
+    assert len(new_entries) >= 1, (
+        f"No new retrieval_detail entry found in {audit_log} for /memory/search. "
+        "AUDIT_LOG_RETRIEVAL_DETAIL may be disabled or the logging code was deleted."
+    )
+
+    entry = new_entries[-1]
+    for field in ("event", "path", "query", "results", "agent_id", "user_id"):
+        assert field in entry, f"Required field '{field}' missing from retrieval_detail entry: {entry}"
+
+    assert entry["event"] == "retrieval_detail"
+    assert entry["path"] == "/memory/search"
+    assert entry["query"] == TEST_QUERY
+    assert entry["agent_id"] == TEST_AGENT
+    assert entry["user_id"] == TEST_USER
+    assert isinstance(entry["results"], list)
+
+
+def test_retrieval_detail_audit_for_search_combined():
+    """
+    /memory/search_combined must write a retrieval_detail entry to the audit log
+    containing all required fields: event, path, query, results, agent_id, user_id.
+    """
+    audit_log = get_today_audit_log()
+    count_before = len(read_retrieval_detail_entries(audit_log, "/memory/search_combined"))
+
+    resp = requests.post(
+        f"{SERVICE_URL}/memory/search_combined",
+        json={"query": TEST_QUERY, "user_id": TEST_USER, "agent_id": TEST_AGENT, "top_k": 3},
+        timeout=30,
+    )
+    assert resp.status_code == 200, f"search_combined returned {resp.status_code}: {resp.text}"
+
+    time.sleep(0.5)
+
+    entries_after = read_retrieval_detail_entries(audit_log, "/memory/search_combined")
+    new_entries = entries_after[count_before:]
+
+    assert len(new_entries) >= 1, (
+        f"No new retrieval_detail entry found in {audit_log} for /memory/search_combined. "
+        "AUDIT_LOG_RETRIEVAL_DETAIL may be disabled or the logging code was deleted."
+    )
+
+    entry = new_entries[-1]
+    for field in ("event", "path", "query", "results", "agent_id", "user_id"):
+        assert field in entry, f"Required field '{field}' missing from retrieval_detail entry: {entry}"
+
+    assert entry["event"] == "retrieval_detail"
+    assert entry["path"] == "/memory/search_combined"
+    assert entry["query"] == TEST_QUERY
+    assert entry["agent_id"] == TEST_AGENT
+    assert entry["user_id"] == TEST_USER
+    assert isinstance(entry["results"], list)


### PR DESCRIPTION
## 背景

PR #133 合并时意外删除了 PR #128 引入的 `retrieval_detail` 审计日志功能，服务正常运行但数据静默丢失约3天，直到人工检查 OpenSearch 才发现。

## 变更内容

### `tests/test_audit_retrieval.py`
3个测试用例：
- `test_service_health` - 服务健康检查
- `test_retrieval_detail_audit_for_search` - 验证 `/memory/search` 写入 `retrieval_detail` 审计记录
- `test_retrieval_detail_audit_for_search_combined` - 验证 `/memory/search_combined` 写入 `retrieval_detail` 审计记录

每个审计测试都验证记录包含所有必需字段：`event`、`path`、`query`、`results`、`agent_id`、`user_id`。

### `.github/workflows/audit-smoke-test.yml`
- 触发：PR 到 main / push 到 main
- 启动 `mem0-api` + `mem0-postgres`（pgvector）via docker compose
- 等待服务健康（最多30s）
- 运行 pytest，失败时打印 audit log 和 docker logs
- always 清理容器

## 本地验证

```
3 passed in 1.73s
```

## 防护效果

如果未来有 PR 再次删除 `_write_retrieval_detail_log()` 调用，CI 会在合并前报错拦截。