### PR TITLE
fix: ci - use docker service name for pgvector host, fix heredoc indent

### DIFF
--- a/.github/workflows/audit-smoke-test.yml
+++ b/.github/workflows/audit-smoke-test.yml
@@ -17,7 +17,7 @@ jobs:
       # Minimal env to boot the service in CI (no real LLM/vector needed for search smoke test)
       AWS_REGION: us-east-1
       VECTOR_STORE: pgvector
-      PGVECTOR_HOST: localhost
+      PGVECTOR_HOST: mem0-postgres
       PGVECTOR_PORT: 5432
       PGVECTOR_DB: mem0
       PGVECTOR_USER: mem0
@@ -49,24 +49,24 @@ jobs:
 
       - name: Write CI .env file
         run: |
-          cat > .env <<EOF
-          AWS_REGION=${AWS_REGION}
-          VECTOR_STORE=${VECTOR_STORE}
-          PGVECTOR_HOST=${PGVECTOR_HOST}
-          PGVECTOR_PORT=${PGVECTOR_PORT}
-          PGVECTOR_DB=${PGVECTOR_DB}
-          PGVECTOR_USER=${PGVECTOR_USER}
-          PGVECTOR_PASSWORD=${PGVECTOR_PASSWORD}
-          PGVECTOR_COLLECTION=${PGVECTOR_COLLECTION}
-          EMBEDDING_MODEL=${EMBEDDING_MODEL}
-          EMBEDDING_DIMS=${EMBEDDING_DIMS}
-          LLM_MODEL=${LLM_MODEL}
-          LLM_TEMPERATURE=${LLM_TEMPERATURE}
-          LLM_MAX_TOKENS=${LLM_MAX_TOKENS}
-          SERVICE_HOST=${SERVICE_HOST}
-          SERVICE_PORT=${SERVICE_PORT}
-          AUDIT_LOG_RETRIEVAL_DETAIL=${AUDIT_LOG_RETRIEVAL_DETAIL}
-          EOF
+          printf '%s\n' \
+            "AWS_REGION=${AWS_REGION}" \
+            "VECTOR_STORE=${VECTOR_STORE}" \
+            "PGVECTOR_HOST=${PGVECTOR_HOST}" \
+            "PGVECTOR_PORT=${PGVECTOR_PORT}" \
+            "PGVECTOR_DB=${PGVECTOR_DB}" \
+            "PGVECTOR_USER=${PGVECTOR_USER}" \
+            "PGVECTOR_PASSWORD=${PGVECTOR_PASSWORD}" \
+            "PGVECTOR_COLLECTION=${PGVECTOR_COLLECTION}" \
+            "EMBEDDING_MODEL=${EMBEDDING_MODEL}" \
+            "EMBEDDING_DIMS=${EMBEDDING_DIMS}" \
+            "LLM_MODEL=${LLM_MODEL}" \
+            "LLM_TEMPERATURE=${LLM_TEMPERATURE}" \
+            "LLM_MAX_TOKENS=${LLM_MAX_TOKENS}" \
+            "SERVICE_HOST=${SERVICE_HOST}" \
+            "SERVICE_PORT=${SERVICE_PORT}" \
+            "AUDIT_LOG_RETRIEVAL_DETAIL=${AUDIT_LOG_RETRIEVAL_DETAIL}" \
+            > .env
 
       - name: Start postgres (pgvector profile)
         run: docker compose --profile pgvector up -d mem0-postgres


### PR DESCRIPTION
## 两个 bug

**Bug 1：PGVECTOR_HOST 应为 docker service name**

`mem0-api` 容器内用 `PGVECTOR_HOST=localhost` 连 postgres，但：
- `localhost` 在容器内指向容器自己，不是 postgres 容器
- 生产上因为用 `network_mode: host` 所以 localhost 能通，但 CI 的 docker compose 没有 host network，两个容器通过 Docker bridge 网络互通
- 必须改成 Docker service name `mem0-postgres`

**Bug 2：heredoc 缩进导致 .env 解析失败**

之前写 .env 用 heredoc 有缩进，生成的 .env 每行前面有空格：
```
          PGVECTOR_HOST=mem0-postgres
```
docker compose 解析 env 文件时会把空格当做变量名一部分，导致环境变量失效。改用 `printf` 生成无缩进的 .env。