### PR TITLE
chore: change auto dream schedule to Beijing Time 02:00 (UTC 18:00)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,7 +21,7 @@ S3VECTORS_BUCKET_NAME=your-s3vectors-bucket
 S3VECTORS_INDEX_NAME=mem0
 
 # PGVector (used when VECTOR_STORE=pgvector)
-# PGVECTOR_HOST=localhost
+# PGVECTOR_HOST=mem0-postgres  # Use service name when running inside Docker Compose (not localhost/127.0.0.1)
 # PGVECTOR_PORT=5432
 # PGVECTOR_DB=mem0
 # PGVECTOR_USER=mem0

--- a/systemd/mem0-dream.timer
+++ b/systemd/mem0-dream.timer
@@ -4,8 +4,8 @@ Documentation=https://github.com/norrishuang/mem0-memory-service
 Requires=mem0-dream.service
 
 [Timer]
-# Run daily at 02:00 UTC (10:00 Beijing Time)
-OnCalendar=*-*-* 02:00:00
+# Run daily at 18:00 UTC (02:00 Beijing Time next day)
+OnCalendar=*-*-* 18:00:00
 Persistent=true
 # If system was offline, run on next boot
 OnBootSec=5min


### PR DESCRIPTION
## Changes

- **`docker/crontab`**: Change `auto_dream` cron from `0 2 * * *` (UTC 02:00 / Beijing 10:00) to `0 18 * * *` (UTC 18:00 / Beijing 02:00)
- **`systemd/mem0-dream.timer`**: Update `OnCalendar` to match the new UTC 18:00 schedule
- **`.env.example`**: Fix `PGVECTOR_HOST` comment — use service name `mem0-postgres` instead of `localhost` when running inside Docker Compose

## Motivation

auto_dream should run at 02:00 Beijing Time (night consolidation), not 10:00 Beijing Time (daytime).

## Notes

- The `.env.example` fix is a bonus: running `docker compose up` without the correct host causes `mem0-api` to fail connecting to postgres (`Connection refused` on 127.0.0.1).