### PR TITLE
fix: 使用专属 extraction prompt 提升 auto_digest 技术上下文保留质量 (#149)

### DIFF
--- a/docs/guide/architecture.md
+++ b/docs/guide/architecture.md
@@ -217,7 +217,7 @@ In practice, we observed 1,800 short-term entries consolidating down to ~78 long
 
 **`auto_digest.py --today` (every 15 min, incremental)**
 
-Runs every 15 minutes, reading only new diary content since the last run. Sends **section-aligned batches** (up to ~50KB each, aligned to `## ` diary section boundaries) to mem0 with `infer=True` — mem0 runs fact extraction to produce concise memories. Offset is saved after each successful batch — if the process is interrupted, the next run picks up where it left off.
+Runs every 15 minutes, reading only new diary content since the last run. Sends **section-aligned batches** (up to ~50KB each, aligned to `## ` diary section boundaries) to mem0 with `infer=True` and a dedicated `DIGEST_EXTRACTION_PROMPT` — a custom prompt that preserves technical identifiers (project names, cluster IDs, service names, port numbers, paths), performance data, work progress, key decisions, and pitfalls. Extraction threshold is 2000 bytes. Offset is saved after each successful batch — if the process is interrupted, the next run picks up where it left off.
 
 This provides **real-time cross-session memory**: conversations from the last ~15 minutes are available for retrieval in other sessions of the same agent.
 

--- a/docs/guide/how-it-works.md
+++ b/docs/guide/how-it-works.md
@@ -109,9 +109,9 @@ On every heartbeat tick, the agent performs memory maintenance in order:
                                        Step2: 7d STM)
               │             │              │              │
               ▼             ▼              ▼              ▼
-         MEMORY.md     mem0 short-    mem0 short-    mem0 long-
+         MEMORY.md     mem0 short-    mem0 long-     mem0 long-
          (updated)     term memory    term memory    term memory
-                       (today,        (yesterday,    (no run_id)
+                       (today,        (no run_id,    (no run_id)
                         ~20min lag)    next day)
                              │
                         UTC 02:00

--- a/docs/guide/how-it-works.md
+++ b/docs/guide/how-it-works.md
@@ -12,7 +12,7 @@ This page explains the end-to-end memory flow — from a conversation happening 
 | **Semantic retrieval, not keyword search** | Find memories by meaning, not exact phrasing | Vector similarity + time-decay blended ranking (`0.7 × score + 0.3 × recency`) |
 | **Cross-agent knowledge sharing** | Lessons learned by one agent instantly benefit all agents | `category=experience` / `procedural` auto-writes to shared pool; every search includes shared pool |
 | **Write generously, dedup automatically** | Agents don't need to worry about redundancy — mem0 handles it | `infer=True` triggers internal fact extraction; same-day dedup is bounded by `run_id` |
-| **Targeted extraction per category** | Different memory types need different extraction angles | `custom_extraction_prompt` per `/memory/add` call; `auto_digest` auto-runs task-extraction pass on every session block |
+| **Targeted extraction per category** | Different memory types need different extraction angles | `custom_extraction_prompt` per `/memory/add` call; `auto_digest` uses `DIGEST_EXTRACTION_PROMPT` for technical context preservation + `TASK_EXTRACTION_PROMPT` for task extraction on every session block |
 | **Three paths to long-term memory** | Different sources land in long-term at different speeds | Explicit CLI write (immediate) → `memory_sync` (same day) → `auto_dream` (7-day cadence) |
 | **Multi-session, multi-agent continuity** | What happens in a group chat is visible to the direct chat session | `session_snapshot` covers all `agent:{id}:*` sessions; ~20 min propagation lag |
 
@@ -207,7 +207,7 @@ When a session's context window grows too large, OpenClaw compresses (compacts) 
 **Tertiary: Near-real-time cross-session memory sharing**
 Each agent may have multiple concurrent sessions — a direct chat session and one or more group chat sessions. Without a sharing mechanism, what an agent says in a group chat is invisible to its direct chat session (and vice versa).
 
-`session_snapshot.py` writes new conversation to the diary file every 5 minutes. `auto_digest.py --today` then picks up new diary content every 15 minutes and writes it to mem0 short-term memory with `infer=True` (run_id=today, fact extraction). Any other session of the same agent can search mem0 and retrieve that content within ~20 minutes (5 min snapshot + 15 min digest) — no session restart required.
+`session_snapshot.py` writes new conversation to the diary file every 5 minutes. `auto_digest.py --today` then picks up new diary content every 15 minutes and writes it to mem0 short-term memory with `infer=True` and `DIGEST_EXTRACTION_PROMPT` (run_id=today, technical context preservation). Any other session of the same agent can search mem0 and retrieve that content within ~20 minutes (5 min snapshot + 15 min digest) — no session restart required.
 
 Session keys are tagged in metadata (`session_key`), so you can filter by source if needed.
 
@@ -433,7 +433,7 @@ Use the key (e.g. `dev`, `main`, `blog`) as your `--agent` value.
 
 The memory pipeline has two stages inspired by how human memory consolidation works:
 
-- **Auto Digest (The Subconscious)** — runs every 15 minutes during the day, continuously absorbing new diary content into short-term memory via dual-pass fact extraction
+- **Auto Digest (The Subconscious)** — runs every 15 minutes during the day, continuously absorbing new diary content into short-term memory via dedicated `DIGEST_EXTRACTION_PROMPT` (technical context preservation) + `TASK_EXTRACTION_PROMPT` (task extraction)
 - **Auto Dream (Deep Sleep)** — runs once at night (UTC 02:00), reflecting on cross-day patterns, promoting 7-day-old short-term memories into long-term, and pruning redundancy
 
 Neither stage requires human intervention. The agent wakes up the next morning with a richer, more organized memory.

--- a/docs/zh/guide/architecture.md
+++ b/docs/zh/guide/architecture.md
@@ -67,7 +67,7 @@ flowchart TD
     Diary["memory/YYYY-MM-DD.md\n（日记文件）"]
     MemoryMD["MEMORY.md\n（Agent 精选知识库）"]
     Snap(["session_snapshot.py\n（每 5 分钟，仅写日记）"])
-    DigestToday(["auto_digest.py --today\n（每 15 分钟，infer=True，fact extraction）"])
+    DigestToday(["auto_digest.py --today\n（每 15 分钟，infer=True，DIGEST_EXTRACTION_PROMPT）"])
     Sync(["memory_sync.py\n（每天 UTC 01:00，同步 MEMORY.md）"])
     Archive(["auto_dream.py\n(AutoDream，UTC 02:00)"])
 
@@ -114,7 +114,7 @@ flowchart TD
 | 组件 | 职责 |
 |---|---|
 | **session_snapshot.py** | 每 5 分钟运行一次。捕获**所有** Agent 会话（单聊 + 群聊）到日记文件。**不直接写入 mem0**——mem0 的写入完全由 auto_digest 负责。 |
-| **auto_digest.py --today** | 每 15 分钟运行一次。读取自上次运行以来日记文件中的**新增字节**（通过 `auto_digest_offset.json` 追踪），以**按 `## ` 章节边界对齐的分批**（每批最大约 50KB）加 `infer=True` 写入 mem0——mem0 内部做 fact extraction，提炼为简洁记忆。每批成功后立即持久化 offset，支持断点续传。 |
+| **auto_digest.py --today** | 每 15 分钟运行一次。读取自上次运行以来日记文件中的**新增字节**（通过 `auto_digest_offset.json` 追踪），以**按 `## ` 章节边界对齐的分批**（每批最大约 50KB）配合 `infer=True` 和专属的 `DIGEST_EXTRACTION_PROMPT` 写入 mem0——该 prompt 专为工程师工作日记设计，重点保留技术标识符、性能数据、工作进展、关键决策和踩坑经验。提炼阈值为 2000 字节。每批成功后立即持久化 offset，支持断点续传。 |
 | **memory_sync.py** | 每天 UTC 01:00 运行。将各 Agent 的 `MEMORY.md`（精选知识）直接同步到 mem0 长期记忆。基于 hash 去重，文件未变化时零 LLM 调用。 |
 | **auto_dream.py** / **AutoDream** | 每天 UTC 02:00 运行。**步骤一**：读取昨日完整日记 → `mem0.add(infer=True, 无 run_id)` → 长期记忆。**步骤二**：对每条 7 天前的短期记忆，调用 `mem0.add(infer=True, 无 run_id)`——mem0 LLM 与已有长期记忆比对，返回四种决策之一：`ADD`（新知识，写入）、`UPDATE`（与已有条目合并）、`DELETE`（冗余，跳过写入）、`NONE`（已完全覆盖，跳过写入）。无论何种决策，**原始短期条目处理后始终删除**。 |
 | **mem0 Memory Service** | 核心服务。使用 AWS Bedrock LLM 进行记忆提炼与去重，使用 Bedrock Embedding 进行向量化。 |

--- a/docs/zh/guide/how-it-works.md
+++ b/docs/zh/guide/how-it-works.md
@@ -105,7 +105,9 @@ Agent 读到「🔴 Agent Memory Behavior」规则
           （agent        auto_digest   auto_dream     memory_sync
            自我提炼）    --today       （Step1:        （同步
                          (infer=True,   昨日日记 +     MEMORY.md）
-                          直接传文本）  Step2: 7天STM）
+                          DIGEST_       Step2: 7天STM）
+                          EXTRACTION_
+                          PROMPT)
               │             │              │              │
               ▼             ▼              ▼              ▼
           MEMORY.md     mem0 短期记忆  mem0 短期记忆  mem0 长期记忆
@@ -154,11 +156,11 @@ Agent 读到「🔴 Agent Memory Behavior」规则
 `auto_digest.py` 只有一种活跃模式：
 
 **`--today` 增量模式（每 15 分钟）**
-基于 offset 记录，每次只读取日记文件自上次运行以来的新增内容。以 `infer=True` 写入 mem0，mem0 内部做 fact extraction，提炼为简洁记忆。新增内容不足 500 字节时跳过，避免无意义的小写入。写入失败时保留 offset，下次从同一断点续传。
+基于 offset 记录，每次只读取日记文件自上次运行以来的新增内容。以 `infer=True` 配合专属的 `DIGEST_EXTRACTION_PROMPT` 写入 mem0——该 prompt 专为工程师工作日记设计，重点保留技术标识符（项目名、集群 ID、服务名、端口号、路径）、性能数据、工作进展、关键决策和踩坑经验。提炼阈值为 2000 字节（从 5000 降低，以捕获较短但有意义的工作片段）。写入失败时保留 offset，下次从同一断点续传。
 
 ```
-每 15 分钟 (--today)：  日记新增内容 → POST 给 mem0（infer=True，fact extraction）
-                       + 任务专项 pass（custom_extraction_prompt → category=task）
+每 15 分钟 (--today)：  日记新增内容 → POST 给 mem0（infer=True，DIGEST_EXTRACTION_PROMPT）
+                       + 任务专项 pass（TASK_EXTRACTION_PROMPT → category=task）
 ```
 
 > **注**：之前的默认全量模式（UTC 01:30，LLM 提取昨日日记 → mem0 短期记忆）已被 `auto_dream.py` Step 1 取代——后者直接写入长期记忆（无 run_id），质量更高。

--- a/docs/zh/guide/how-it-works.md
+++ b/docs/zh/guide/how-it-works.md
@@ -110,8 +110,8 @@ Agent 读到「🔴 Agent Memory Behavior」规则
                           PROMPT)
               │             │              │              │
               ▼             ▼              ▼              ▼
-          MEMORY.md     mem0 短期记忆  mem0 短期记忆  mem0 长期记忆
-          （已更新）     （今日，       （昨日，        （无 run_id）
+          MEMORY.md     mem0 短期记忆  mem0 长期记忆  mem0 长期记忆
+          （已更新）     （今日，       （无 run_id，   （无 run_id）
                           约 20 分钟    次日生效）
                           延迟）
                              │

--- a/pipelines/auto_digest.py
+++ b/pipelines/auto_digest.py
@@ -33,7 +33,7 @@ _raw_url = os.environ.get("MEM0_API_URL", "http://127.0.0.1:8230")
 MEM0_BASE_URL = _raw_url.removesuffix("/memory/add").removesuffix("/")
 MEM0_API_URL = f"{MEM0_BASE_URL}/memory/add"
 MEM0_DREAM_URL = f"{MEM0_BASE_URL}/memory/dream"
-MIN_CONTENT_BYTES = 5000   # 新增内容少于此值则跳过（避免无意义的小更新）
+MIN_CONTENT_BYTES = 2000   # 新增内容少于此值则跳过（避免无意义的小更新）
 MAX_BLOCK_BYTES = 100 * 1024  # Max bytes per session block before sub-splitting (100KB)
 BATCH_SIZE_BYTES = MAX_BLOCK_BYTES  # Legacy alias — only used as fallback for oversized blocks
 BATCH_SLEEP_SECS = 5      # 批次间 sleep，避免打爆 mem0
@@ -177,12 +177,13 @@ def write_to_mem0(event: str, run_id: str, agent_id: str, incremental: bool = Fa
             "workspace_agent": agent_id
         }
 
-        resp = requests.post(MEM0_API_URL, json={
+        resp = requests.post(MEM0_DREAM_URL, json={
             "user_id": "boss",
             "agent_id": agent_id,
             "run_id": run_id,
             "text": event,
             "infer": True,
+            "custom_extraction_prompt": DIGEST_EXTRACTION_PROMPT,
             "metadata": metadata
         }, timeout=120)
         resp.raise_for_status()
@@ -194,6 +195,25 @@ def write_to_mem0(event: str, run_id: str, agent_id: str, incremental: bool = Fa
 
 
 
+
+DIGEST_EXTRACTION_PROMPT = (
+    "你是一位技术助理，负责从工程师的工作日记中提炼关键技术信息以便未来快速恢复上下文。\n\n"
+    "请从以下对话日记中提炼最重要的技术事实，重点关注：\n"
+    "- 具体的项目名称、集群 ID、服务名、端口号、路径等可识别标识\n"
+    "- 性能数据、测试结果（如吞吐量、延迟、错误率等具体数值）\n"
+    "- 当前工作阶段和进展状态（正在做什么、做到哪一步了）\n"
+    "- 关键技术决策和选型理由\n"
+    "- 遇到的问题和解决方案（特别是踩过的坑）\n"
+    "- 待办事项和下一步计划\n\n"
+    "要求：\n"
+    "- 每条事实自完备、可独立理解，不依赖上下文\n"
+    "- 保留具体数值和标识符，不要用模糊描述替代\n"
+    "- 每条 30-80 字，中文\n"
+    "- 不超过 10 条，只写有实质内容的事实\n"
+    "- 不要写流水账（'执行了 git pull' 这类无意义操作不要写）\n\n"
+    "输出格式（必须严格遵守）：{\"facts\": [\"事实1\", \"事实2\", ...]}\n"
+    "如无实质内容，返回：{\"facts\": []}"
+)
 
 TASK_EXTRACTION_PROMPT = (
     "从以下对话日记中列出agent实际完成的工作任务（最终成果），每行一条，"


### PR DESCRIPTION
## 问题

关闭 #149

auto_digest.py 使用 mem0 的**默认 fact extraction prompt** 提炼日记内容，该 prompt 为个人助理场景设计，对技术工程场景极不友好，导致 session 压缩后大量技术上下文丢失。

**之前的效果：**
- 输入：HBase Replication 压测，集群 j-395KBAFSTTCD3，积压 782 个 WAL，37 分钟追平，吞吐 14.8 万 ops/sec
- 输出：`"测试 HBase 的 HDFS WAL 配置"`（关键信息全丢）

## 改动

### pipelines/auto_digest.py

1. **新增 `DIGEST_EXTRACTION_PROMPT`** — 专为工程师工作日记设计，重点保留：
   - 项目名、集群 ID、服务名、端口号、路径等可识别标识
   - 性能数据、测试结果（具体数值）
   - 当前工作阶段和进展状态
   - 关键技术决策和选型理由
   - 踩坑记录和解决方案
   - 待办事项和下一步计划

2. **`write_to_mem0` 改用 `/memory/dream` 端点**，传入 `custom_extraction_prompt: DIGEST_EXTRACTION_PROMPT`，替换 mem0 默认 prompt

3. **`MIN_CONTENT_BYTES` 从 5000 → 2000**，减少因阈值过高导致的漏提取窗口

### 文档更新

- `docs/guide/how-it-works.md` 及 `docs/zh/guide/how-it-works.md`：更新 auto_digest 流程说明、双 Pass 流程图、时序图
- `docs/guide/architecture.md` 及 `docs/zh/guide/architecture.md`：更新组件职责表、Mermaid 架构图、设计理念章节

## 验证

改后对技术工作日记重跑 auto_digest，提炼结果应包含具体的集群 ID、性能数值、工作阶段等关键技术细节，而非模糊的一句话描述。