### PR TITLE
feat: add OpenClaw plugin for real-time mem0 memory integration

### DIFF
--- a/docs/openclaw-plugin.md
+++ b/docs/openclaw-plugin.md
@@ -188,7 +188,7 @@ Real-time path (Plugin):
   Prompt       → before_prompt_build → search → inject
 
 Batch path (Pipelines):
-  Session → session_snapshot (5 min) → diary file
+  Session → session_snapshot (every 15 min) → diary file
   Diary   → auto_digest (daily UTC 01:30) → mem0 short-term
   Nightly → auto_dream (UTC 18:00) → long-term consolidation
 ```

--- a/docs/openclaw-plugin.md
+++ b/docs/openclaw-plugin.md
@@ -1,0 +1,197 @@
+# OpenClaw Plugin
+
+The mem0 Memory Plugin hooks into OpenClaw's agent lifecycle to provide real-time memory capture and retrieval — no cron jobs, no diary files. Every meaningful conversation turn is written to mem0 as it happens, and relevant memories are injected into the system prompt before each response.
+
+## Architecture
+
+### How the Plugin Fits into the Memory System
+
+```mermaid
+flowchart LR
+    subgraph Realtime["Real-time (Plugin)"]
+        P["OpenClaw Plugin"]
+    end
+    subgraph Batch["Batch (Pipelines)"]
+        D["auto_digest\n(every 15 min)"]
+        DR["auto_dream\n(daily UTC 02:00)"]
+    end
+
+    Conv["Conversations"] --> P -->|"raw write\n(infer=false)"| Mem0[("mem0\nVector Store")]
+    Diary["Diary Files"] --> D -->|"infer=true"| Mem0
+    Mem0 -->|"7-day short-term"| DR -->|"consolidate"| Mem0
+    Mem0 -->|"search"| P -->|"inject into\nsystem prompt"| Conv
+```
+
+The plugin and the existing pipelines are complementary:
+
+| Component | Trigger | Write Mode | Purpose |
+|-----------|---------|------------|---------|
+| **Plugin** (`agent_end`) | Every conversation turn | `infer=false` (raw) | Immediate capture, zero LLM cost |
+| **Plugin** (`before_compaction`) | Before session compaction | `infer=true` | LLM-distilled write before context is lost |
+| **Plugin** (`before_prompt_build`) | Before each response | Search only | Inject relevant memories into prompt |
+| `auto_digest` | Every 15 min (cron) | `infer=true` | Extract facts from diary files |
+| `auto_dream` | Daily UTC 02:00 (cron) | `infer=true` | Consolidate short-term → long-term |
+
+### Sequence: Normal Conversation Turn
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant OC as OpenClaw Agent
+    participant P as Plugin
+    participant M as mem0 Service
+
+    U->>OC: Send message
+    P->>M: Search relevant memories (before_prompt_build)
+    M-->>P: Return matching memories
+    P-->>OC: Inject memories into system prompt
+    OC->>U: Respond
+    OC->>P: agent_end event
+    P->>M: POST /memory/add (infer=false)
+    Note over P,M: Raw text stored, no LLM cost
+```
+
+### Sequence: Session Compaction
+
+```mermaid
+sequenceDiagram
+    participant OC as OpenClaw
+    participant P as Plugin
+    participant M as mem0 Service
+    participant LLM as AWS Bedrock
+
+    OC->>P: before_compaction event
+    P->>M: POST /memory/add (infer=true)
+    M->>LLM: Extract key facts
+    LLM-->>M: Distilled memories
+    M-->>P: OK
+    OC->>OC: Execute compaction
+    Note over OC: Context window compressed,<br/>but memories are preserved in mem0
+```
+
+## Plugin Hooks
+
+### `agent_end` — Write Conversation Turns
+
+Fires after each agent turn completes successfully. Extracts the last user+assistant exchange and writes it to mem0.
+
+**Behavior:**
+- Skips if the exchange is shorter than `minExchangeLength` (default 100 chars)
+- Debounced per session — at most one write per `debounceMs` (default 60s)
+- Writes with `infer=false` by default (raw text, no LLM cost)
+- Set `enableWrite=true` to use `infer=true` instead (LLM extracts key facts)
+
+### `before_compaction` — Flush Before Context Loss
+
+Fires when OpenClaw is about to compress the session context. Writes the last exchange to mem0 with `infer=true` so the LLM distills key facts before the full context is lost.
+
+**Behavior:**
+- Always uses `infer=true` — this is the last chance to capture context
+- No debounce — compaction is infrequent and critical
+
+### `before_prompt_build` — Inject Memories
+
+Fires before each agent response is generated. Searches mem0 for memories relevant to the current user prompt and prepends them to the system context.
+
+**Behavior:**
+- Extracts the first 200 characters of the user prompt as the search query
+- Returns up to `injectLimit` results (default 5), truncated to `injectMaxChars` (default 800)
+- Times out after `injectTimeoutMs` (default 3s) — silently skips on timeout
+- Injected as a `## Relevant Memories` section prepended to the prompt
+
+## Configuration
+
+All configuration is set in `openclaw.plugin.json` or passed via OpenClaw's plugin config system.
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `mem0Url` | string | `http://localhost:8230` | mem0 service endpoint |
+| `userId` | string | `boss` | User ID for mem0 operations |
+| `agentIds` | string[] | `["dev","main","pm","researcher","pjm","prototype"]` | Agent IDs to process (empty = all) |
+| `enableWrite` | boolean | `true` | Enable `agent_end` writes with `infer=true` |
+| `enableRawWrite` | boolean | `false` | Enable `agent_end` writes with `infer=false` (takes effect when `enableWrite=false`) |
+| `enableInject` | boolean | `true` | Enable memory injection via `before_prompt_build` |
+| `minExchangeLength` | number | `100` | Minimum exchange length (chars) to trigger a write |
+| `injectLimit` | number | `5` | Max memories to inject per prompt |
+| `injectMaxChars` | number | `800` | Max total chars for injected memories |
+| `debounceMs` | number | `60000` | Debounce interval per session (ms) |
+| `injectTimeoutMs` | number | `3000` | Timeout for memory search (ms) |
+
+> **`enableWrite` vs `enableRawWrite`**: When `enableWrite=true`, conversations are written with `infer=true` (LLM extracts facts — higher quality, costs LLM tokens). When `enableWrite=false` and `enableRawWrite=true`, conversations are stored as raw text with `infer=false` (zero LLM cost, relies on `auto_dream` for later distillation). Only one mode is active at a time; `enableWrite` takes priority.
+
+## Installation
+
+### 1. Copy the Plugin
+
+```bash
+cp -r openclaw-plugin ~/.openclaw/plugins/mem0-memory-plugin
+```
+
+### 2. Enable in OpenClaw Settings
+
+Add the plugin to your `openclaw.json`:
+
+```json
+{
+  "plugins": {
+    "mem0-memory-plugin": {
+      "enabled": true,
+      "config": {
+        "mem0Url": "http://localhost:8230",
+        "userId": "boss",
+        "enableWrite": false,
+        "enableRawWrite": true,
+        "enableInject": true
+      }
+    }
+  }
+}
+```
+
+### 3. Verify
+
+After enabling, check the OpenClaw logs for:
+
+```
+[mem0-plugin] Registered. mem0Url=http://localhost:8230 userId=boss agentIds=dev,main,pm,researcher,pjm,prototype
+```
+
+## Recommended Setup
+
+For most users, we recommend **raw write mode** (`enableRawWrite=true`, `enableWrite=false`):
+
+```json
+{
+  "enableWrite": false,
+  "enableRawWrite": true,
+  "enableInject": true
+}
+```
+
+**Why?**
+- `agent_end` writes raw text with zero LLM cost — conversations are captured immediately
+- `before_compaction` always uses `infer=true` — critical context is distilled before loss
+- `auto_dream` (nightly) consolidates raw memories into high-quality long-term knowledge
+- Memory injection gives agents context from past conversations in real time
+
+This gives you the best balance of cost, latency, and memory quality.
+
+## Relationship with Existing Pipelines
+
+The plugin does **not** replace the existing pipeline system. They work together:
+
+```
+Real-time path (Plugin):
+  Conversation → agent_end → mem0 (raw, immediate)
+  Compaction   → before_compaction → mem0 (infer, critical)
+  Prompt       → before_prompt_build → search → inject
+
+Batch path (Pipelines):
+  Session → session_snapshot (5 min) → diary file
+  Diary   → auto_digest (15 min) → mem0 short-term
+  Nightly → auto_dream (UTC 02:00) → long-term consolidation
+```
+
+- **Plugin** provides real-time capture and retrieval — no delay between conversation and memory availability
+- **Pipelines** provide structured diary management and nightly consolidation — higher quality long-term memories
+- Both paths write to the same mem0 instance — mem0's built-in deduplication prevents duplicates

--- a/docs/openclaw-plugin.md
+++ b/docs/openclaw-plugin.md
@@ -12,8 +12,8 @@ flowchart LR
         P["OpenClaw Plugin"]
     end
     subgraph Batch["Batch (Pipelines)"]
-        D["auto_digest\n(every 15 min)"]
-        DR["auto_dream\n(daily UTC 02:00)"]
+        D["auto_digest\n(daily UTC 01:30)"]
+        DR["auto_dream\n(daily UTC 18:00)"]
     end
 
     Conv["Conversations"] --> P -->|"raw write\n(infer=false)"| Mem0[("mem0\nVector Store")]
@@ -29,8 +29,8 @@ The plugin and the existing pipelines are complementary:
 | **Plugin** (`agent_end`) | Every conversation turn | `infer=false` (raw) | Immediate capture, zero LLM cost |
 | **Plugin** (`before_compaction`) | Before session compaction | `infer=true` | LLM-distilled write before context is lost |
 | **Plugin** (`before_prompt_build`) | Before each response | Search only | Inject relevant memories into prompt |
-| `auto_digest` | Every 15 min (cron) | `infer=true` | Extract facts from diary files |
-| `auto_dream` | Daily UTC 02:00 (cron) | `infer=true` | Consolidate short-term → long-term |
+| `auto_digest` | Daily UTC 01:30 (cron) | `infer=true` | Extract facts from diary files |
+| `auto_dream` | Daily UTC 18:00 (cron) | `infer=true` | Consolidate short-term → long-term |
 
 ### Sequence: Normal Conversation Turn
 
@@ -108,9 +108,10 @@ All configuration is set in `openclaw.plugin.json` or passed via OpenClaw's plug
 | `mem0Url` | string | `http://localhost:8230` | mem0 service endpoint |
 | `userId` | string | `boss` | User ID for mem0 operations |
 | `agentIds` | string[] | `["dev","main","pm","researcher","pjm","prototype"]` | Agent IDs to process (empty = all) |
-| `enableWrite` | boolean | `true` | Enable `agent_end` writes with `infer=true` |
-| `enableRawWrite` | boolean | `false` | Enable `agent_end` writes with `infer=false` (takes effect when `enableWrite=false`) |
-| `enableInject` | boolean | `true` | Enable memory injection via `before_prompt_build` |
+| `enableWrite` | boolean | `false` | Enable `agent_end` writes with `infer=true` |
+| `enableRawWrite` | boolean | `true` | Enable `agent_end` writes with `infer=false` (takes effect when `enableWrite=false`) |
+| `enableInject` | boolean | `false` | Enable memory injection via `before_prompt_build` |
+| `enableCompactionFlush` | boolean | `true` | Enable `before_compaction` flush to mem0 |
 | `minExchangeLength` | number | `100` | Minimum exchange length (chars) to trigger a write |
 | `injectLimit` | number | `5` | Max memories to inject per prompt |
 | `injectMaxChars` | number | `800` | Max total chars for injected memories |
@@ -188,8 +189,8 @@ Real-time path (Plugin):
 
 Batch path (Pipelines):
   Session → session_snapshot (5 min) → diary file
-  Diary   → auto_digest (15 min) → mem0 short-term
-  Nightly → auto_dream (UTC 02:00) → long-term consolidation
+  Diary   → auto_digest (daily UTC 01:30) → mem0 short-term
+  Nightly → auto_dream (UTC 18:00) → long-term consolidation
 ```
 
 - **Plugin** provides real-time capture and retrieval — no delay between conversation and memory availability

--- a/docs/openclaw-plugin.zh.md
+++ b/docs/openclaw-plugin.zh.md
@@ -1,0 +1,196 @@
+# OpenClaw 插件
+
+mem0 Memory Plugin 通过 Hook 系统接入 OpenClaw 的 agent 生命周期，实现实时记忆写入——无需 cron 任务，无需日记文件。每次有实质内容的对话都会即时写入 mem0，同时在生成回复前将相关记忆注入系统提示。
+
+## 架构
+
+### 插件在整个记忆系统中的位置
+
+```mermaid
+flowchart LR
+    subgraph Realtime["实时（插件）"]
+        P["OpenClaw 插件"]
+    end
+    subgraph Batch["批处理（流水线）"]
+        D["auto_digest\n（每小时）"]
+        DR["auto_dream\n（每天 UTC 02:00）"]
+    end
+
+    Conv["对话"] --> P -->|"原文写入\n(infer=false)"| Mem0[("mem0\n向量数据库")]
+    Diary["日记文件"] --> D -->|"infer=true"| Mem0
+    Mem0 -->|"7天短期记忆"| DR -->|"精炼合并"| Mem0
+    Mem0 -->|"搜索"| P -->|"注入系统提示"| Conv
+```
+
+插件与现有流水线互补，各司其职：
+
+| 组件 | 触发时机 | 写入方式 | 用途 |
+|------|---------|---------|------|
+| **插件**（`agent_end`） | 每次对话 turn 结束 | `infer=false`（原文） | 即时捕获，零 LLM 开销 |
+| **插件**（`before_compaction`） | session 压缩前 | `infer=true` | 压缩前 LLM 提炼，防止上下文丢失 |
+| **插件**（`before_prompt_build`） | 每次生成回复前 | 仅搜索 | 将相关记忆注入 prompt |
+| `auto_digest` | 每小时（cron） | `infer=true` | 从日记文件提取结构化记忆 |
+| `auto_dream` | 每天 UTC 02:00 | `infer=true` | 短期记忆 → 长期记忆精炼 |
+
+### 时序图：正常对话 turn
+
+```mermaid
+sequenceDiagram
+    participant U as 用户
+    participant OC as OpenClaw Agent
+    participant P as 插件
+    participant M as mem0 服务
+
+    U->>OC: 发送消息
+    P->>M: 搜索相关记忆（before_prompt_build）
+    M-->>P: 返回匹配记忆
+    P-->>OC: 注入记忆到系统提示
+    OC->>U: 回复
+    OC->>P: agent_end 事件
+    P->>M: POST /memory/add（infer=false）
+    Note over P,M: 原文存储，无 LLM 开销
+```
+
+### 时序图：session 压缩时
+
+```mermaid
+sequenceDiagram
+    participant OC as OpenClaw
+    participant P as 插件
+    participant M as mem0 服务
+    participant LLM as AWS Bedrock
+
+    OC->>P: before_compaction 事件
+    P->>M: POST /memory/add（infer=true）
+    M->>LLM: 提取关键信息
+    LLM-->>M: 精炼后的记忆
+    M-->>P: 写入成功
+    OC->>OC: 执行 session 压缩
+    Note over OC: 上下文窗口被压缩，<br/>但关键内容已保存在 mem0 中
+```
+
+## Hook 说明
+
+### `agent_end` — 写入对话内容
+
+每次 agent turn 成功结束后触发，提取最后一轮 user + assistant 对话写入 mem0。
+
+**行为：**
+- 对话内容不足 `minExchangeLength`（默认 100 字）时跳过，过滤寒暄等无效内容
+- 每个 session 有 debounce 保护，`debounceMs`（默认 60 秒）内最多写一次
+- `enableRawWrite=true` 时使用 `infer=false`（原文存储，零 LLM 开销）
+- `enableWrite=true` 时使用 `infer=true`（LLM 提取关键事实，质量更高但有开销）
+
+### `before_compaction` — 压缩前兜底写入
+
+OpenClaw 即将压缩 session 上下文时触发，将当前对话以 `infer=true` 写入 mem0，确保在上下文丢失前完成 LLM 提炼。
+
+**行为：**
+- 始终使用 `infer=true`——这是压缩前最后的捕获机会
+- 无 debounce 限制——压缩频率低且关键
+
+### `before_prompt_build` — 注入记忆
+
+每次生成回复前触发，用当前用户消息搜索 mem0，将相关记忆前置注入系统上下文。
+
+**行为：**
+- 取用户消息前 200 字作为搜索 query
+- 最多返回 `injectLimit`（默认 5）条，截断至 `injectMaxChars`（默认 800 字）
+- 超过 `injectTimeoutMs`（默认 3 秒）自动跳过，不阻塞回复
+- 以 `## Relevant Memories` 段落形式注入系统提示
+
+## 配置项
+
+所有配置通过 OpenClaw 的 `plugins.entries` 传入。
+
+| 配置项 | 类型 | 默认值 | 说明 |
+|--------|------|--------|------|
+| `mem0Url` | string | `http://localhost:8230` | mem0 服务地址 |
+| `userId` | string | `boss` | mem0 用户 ID |
+| `agentIds` | string[] | `["dev","main","pm","researcher","pjm","prototype"]` | 处理的 agent ID 列表（空数组=全部） |
+| `enableWrite` | boolean | `true` | 开启 `agent_end` 写入（infer=true） |
+| `enableRawWrite` | boolean | `false` | 开启 `agent_end` 原文写入（infer=false，enableWrite=false 时生效） |
+| `enableInject` | boolean | `true` | 开启 `before_prompt_build` 记忆注入 |
+| `minExchangeLength` | number | `100` | 触发写入的最小对话长度（字符数） |
+| `injectLimit` | number | `5` | 每次注入的最大记忆条数 |
+| `injectMaxChars` | number | `800` | 注入内容的最大字符数 |
+| `debounceMs` | number | `60000` | 每个 session 写入去重窗口（毫秒） |
+| `injectTimeoutMs` | number | `3000` | 记忆搜索超时时间（毫秒） |
+
+> **`enableWrite` 与 `enableRawWrite` 的区别**：`enableWrite=true` 时对话以 `infer=true` 写入，LLM 自动提取关键事实（质量高，有 LLM 开销）。`enableWrite=false` 且 `enableRawWrite=true` 时以原文写入（零 LLM 开销，依赖 `auto_dream` 夜间精炼）。两者互斥，`enableWrite` 优先级更高。
+
+## 安装配置
+
+### 1. 加载插件
+
+在 `~/.openclaw/openclaw.json` 中添加插件加载路径：
+
+```json
+{
+  "plugins": {
+    "load": {
+      "paths": [
+        "/path/to/mem0-memory-service/openclaw-plugin"
+      ]
+    },
+    "entries": {
+      "openclaw-plugin": {
+        "enabled": true,
+        "config": {
+          "mem0Url": "http://localhost:8230",
+          "userId": "boss",
+          "enableWrite": false,
+          "enableRawWrite": true,
+          "enableInject": false
+        }
+      }
+    }
+  }
+}
+```
+
+### 2. 验证加载成功
+
+重启 OpenClaw 后，查看日志中是否出现：
+
+```
+[mem0-plugin] Registered. mem0Url=http://localhost:8230 userId=boss agentIds=dev,main,pm,...
+```
+
+## 推荐配置
+
+对大多数用户，建议使用**原文写入模式**（`enableRawWrite=true`，`enableWrite=false`）：
+
+```json
+{
+  "enableWrite": false,
+  "enableRawWrite": true,
+  "enableInject": false
+}
+```
+
+**原因：**
+- `agent_end` 原文写入，零 LLM 开销，对话即时被捕获
+- `before_compaction` 始终使用 `infer=true`，关键上下文在压缩前得到提炼
+- `auto_dream` 每晚将原文记忆整合为高质量长期知识
+- 注入功能（`enableInject`）可按需开启，频率高时建议关闭
+
+## 与现有流水线的关系
+
+插件**不替代**现有的流水线系统，两者协作运行：
+
+```
+实时路径（插件）：
+  对话  → agent_end          → mem0（原文，即时）
+  压缩  → before_compaction  → mem0（LLM提炼，兜底）
+  提示  → before_prompt_build → 搜索 → 注入
+
+批处理路径（流水线）：
+  session → session_snapshot（5分钟）→ 日记文件
+  日记    → auto_digest（每小时）     → mem0 短期记忆
+  每晚    → auto_dream（UTC 02:00）   → 长期记忆精炼
+```
+
+- **插件**提供实时捕获——对话结束即可被记忆，无延迟
+- **流水线**提供结构化日记管理和夜间精炼——长期记忆质量更高
+- 两条路径写入同一个 mem0 实例，mem0 内置去重机制防止重复

--- a/docs/openclaw-plugin.zh.md
+++ b/docs/openclaw-plugin.zh.md
@@ -12,8 +12,8 @@ flowchart LR
         P["OpenClaw 插件"]
     end
     subgraph Batch["批处理（流水线）"]
-        D["auto_digest\n（每小时）"]
-        DR["auto_dream\n（每天 UTC 02:00）"]
+        D["auto_digest\n（每天 UTC 01:30）"]
+        DR["auto_dream\n（每天 UTC 18:00）"]
     end
 
     Conv["对话"] --> P -->|"原文写入\n(infer=false)"| Mem0[("mem0\n向量数据库")]
@@ -29,8 +29,8 @@ flowchart LR
 | **插件**（`agent_end`） | 每次对话 turn 结束 | `infer=false`（原文） | 即时捕获，零 LLM 开销 |
 | **插件**（`before_compaction`） | session 压缩前 | `infer=true` | 压缩前 LLM 提炼，防止上下文丢失 |
 | **插件**（`before_prompt_build`） | 每次生成回复前 | 仅搜索 | 将相关记忆注入 prompt |
-| `auto_digest` | 每小时（cron） | `infer=true` | 从日记文件提取结构化记忆 |
-| `auto_dream` | 每天 UTC 02:00 | `infer=true` | 短期记忆 → 长期记忆精炼 |
+| `auto_digest` | 每天 UTC 01:30（cron） | `infer=true` | 从日记文件提取结构化记忆 |
+| `auto_dream` | 每天 UTC 18:00 | `infer=true` | 短期记忆 → 长期记忆精炼 |
 
 ### 时序图：正常对话 turn
 
@@ -108,9 +108,10 @@ OpenClaw 即将压缩 session 上下文时触发，将当前对话以 `infer=tru
 | `mem0Url` | string | `http://localhost:8230` | mem0 服务地址 |
 | `userId` | string | `boss` | mem0 用户 ID |
 | `agentIds` | string[] | `["dev","main","pm","researcher","pjm","prototype"]` | 处理的 agent ID 列表（空数组=全部） |
-| `enableWrite` | boolean | `true` | 开启 `agent_end` 写入（infer=true） |
-| `enableRawWrite` | boolean | `false` | 开启 `agent_end` 原文写入（infer=false，enableWrite=false 时生效） |
-| `enableInject` | boolean | `true` | 开启 `before_prompt_build` 记忆注入 |
+| `enableWrite` | boolean | `false` | 开启 `agent_end` 写入（infer=true） |
+| `enableRawWrite` | boolean | `true` | 开启 `agent_end` 原文写入（infer=false，enableWrite=false 时生效） |
+| `enableInject` | boolean | `false` | 开启 `before_prompt_build` 记忆注入 |
+| `enableCompactionFlush` | boolean | `true` | 开启 `before_compaction` 压缩前写入 |
 | `minExchangeLength` | number | `100` | 触发写入的最小对话长度（字符数） |
 | `injectLimit` | number | `5` | 每次注入的最大记忆条数 |
 | `injectMaxChars` | number | `800` | 注入内容的最大字符数 |
@@ -187,8 +188,8 @@ OpenClaw 即将压缩 session 上下文时触发，将当前对话以 `infer=tru
 
 批处理路径（流水线）：
   session → session_snapshot（5分钟）→ 日记文件
-  日记    → auto_digest（每小时）     → mem0 短期记忆
-  每晚    → auto_dream（UTC 02:00）   → 长期记忆精炼
+  日记    → auto_digest（每天 UTC 01:30）  → mem0 短期记忆
+  每晚    → auto_dream（UTC 18:00）        → 长期记忆精炼
 ```
 
 - **插件**提供实时捕获——对话结束即可被记忆，无延迟

--- a/docs/openclaw-plugin.zh.md
+++ b/docs/openclaw-plugin.zh.md
@@ -187,7 +187,7 @@ OpenClaw 即将压缩 session 上下文时触发，将当前对话以 `infer=tru
   提示  → before_prompt_build → 搜索 → 注入
 
 批处理路径（流水线）：
-  session → session_snapshot（5分钟）→ 日记文件
+  session → session_snapshot（每15分钟）→ 日记文件
   日记    → auto_digest（每天 UTC 01:30）  → mem0 短期记忆
   每晚    → auto_dream（UTC 18:00）        → 长期记忆精炼
 ```

--- a/openclaw-plugin/index.js
+++ b/openclaw-plugin/index.js
@@ -12,7 +12,9 @@ const DEFAULT_CONFIG = {
   userId: "boss",
   agentIds: ["dev", "main", "pm", "researcher", "pjm", "prototype"],
   enableWrite: true,
+  enableRawWrite: false,
   enableInject: true,
+  minExchangeLength: 100,
   injectLimit: 5,
   injectMaxChars: 800,
   debounceMs: 60000, // 1 minute debounce per sessionKey
@@ -90,13 +92,13 @@ function extractTextContent(content) {
   return String(content).slice(0, 2000);
 }
 
-async function writeToMem0(cfg, agentId, text) {
+async function writeToMem0(cfg, agentId, text, infer = true) {
   const url = `${cfg.mem0Url}/memory/add`;
   const body = JSON.stringify({
     text,
     user_id: cfg.userId,
     agent_id: agentId,
-    infer: true,
+    infer,
   });
 
   const resp = await fetch(url, {
@@ -166,31 +168,35 @@ const plugin = {
       `[mem0-plugin] Registered. mem0Url=${cfg.mem0Url} userId=${cfg.userId} agentIds=${cfg.agentIds.join(",")}`
     );
     console.log(
-      `[mem0-plugin] enableWrite=${cfg.enableWrite} enableInject=${cfg.enableInject}`
+      `[mem0-plugin] enableWrite=${cfg.enableWrite} enableRawWrite=${cfg.enableRawWrite} enableInject=${cfg.enableInject}`
     );
 
     // ── 1. agent_end: write conversation turn to mem0 ──
-    if (cfg.enableWrite) {
+    if (cfg.enableWrite || cfg.enableRawWrite) {
       api.on("agent_end", async (event, ctx) => {
         try {
           if (!event.success) return;
           const agentId = ctx.agentId;
           if (!shouldProcess(agentId, cfg)) return;
-          if (isDebounced(ctx.sessionKey, cfg)) {
-            console.log(
-              `[mem0-plugin] agent_end debounced for session=${ctx.sessionKey}`
-            );
-            return;
-          }
+          if (isDebounced(ctx.sessionKey, cfg)) return;
 
           const exchange = extractLastExchange(event.messages);
           if (!exchange) return;
 
-          await writeToMem0(cfg, agentId, exchange);
-          markWritten(ctx.sessionKey);
-          console.log(
-            `[mem0-plugin] agent_end: wrote to mem0 agent=${agentId} session=${ctx.sessionKey}`
-          );
+          // 过滤太短的内容（纯寒暄/确认）
+          if (exchange.length < cfg.minExchangeLength) return;
+
+          if (cfg.enableWrite) {
+            // infer=true，让 mem0 自动提炼
+            await writeToMem0(cfg, agentId, exchange, true);
+            markWritten(ctx.sessionKey);
+            console.log(`[mem0-plugin] agent_end: infer write agent=${agentId}`);
+          } else if (cfg.enableRawWrite) {
+            // infer=false，原文存入
+            await writeToMem0(cfg, agentId, exchange, false);
+            markWritten(ctx.sessionKey);
+            console.log(`[mem0-plugin] agent_end: raw write agent=${agentId}`);
+          }
         } catch (err) {
           console.error(`[mem0-plugin] agent_end error:`, err.message);
         }
@@ -208,7 +214,7 @@ const plugin = {
           const exchange = extractLastExchange(messages);
           if (!exchange) return;
 
-          await writeToMem0(cfg, agentId, exchange);
+          await writeToMem0(cfg, agentId, exchange, true);
           markWritten(ctx.sessionKey);
           console.log(
             `[mem0-plugin] before_compaction: flushed to mem0 agent=${agentId}`

--- a/openclaw-plugin/index.js
+++ b/openclaw-plugin/index.js
@@ -118,7 +118,7 @@ function extractTextContent(content) {
   return String(content).slice(0, 2000);
 }
 
-async function writeToMem0(cfg, agentId, text, infer = true) {
+async function writeToMem0(cfg, agentId, text, infer = true, timeoutMs = 5000) {
   const url = `${cfg.mem0Url}/memory/add`;
   const body = JSON.stringify({
     text,
@@ -131,7 +131,7 @@ async function writeToMem0(cfg, agentId, text, infer = true) {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body,
-    signal: AbortSignal.timeout(5000),
+    signal: AbortSignal.timeout(timeoutMs),
   });
 
   if (!resp.ok) {
@@ -242,7 +242,7 @@ const plugin = {
           const fullContext = extractAllMessages(messages, cfg.compactionMaxChars);
           if (!fullContext) return;
 
-          await writeToMem0(cfg, agentId, fullContext, true);
+          await writeToMem0(cfg, agentId, fullContext, true, 120000); // 120s timeout for large flush
           markWritten(ctx.sessionKey);
           console.log(
             `[mem0-plugin] before_compaction: flushed ${fullContext.length} chars agent=${agentId}`

--- a/openclaw-plugin/index.js
+++ b/openclaw-plugin/index.js
@@ -1,0 +1,256 @@
+/**
+ * OpenClaw mem0 Memory Plugin
+ *
+ * Hooks into OpenClaw's agent lifecycle to:
+ * - Write conversation turns to mem0 (agent_end hook)
+ * - Inject relevant memories into system prompt (before_prompt_build hook)
+ * - Flush conversation to mem0 before compaction (before_compaction hook)
+ */
+
+const DEFAULT_CONFIG = {
+  mem0Url: "http://localhost:8230",
+  userId: "boss",
+  agentIds: ["dev", "main", "pm", "researcher", "pjm", "prototype"],
+  enableWrite: true,
+  enableInject: true,
+  injectLimit: 5,
+  injectMaxChars: 800,
+  debounceMs: 60000, // 1 minute debounce per sessionKey
+  injectTimeoutMs: 3000,
+};
+
+// Debounce map: sessionKey -> last write timestamp
+const lastWriteMap = new Map();
+
+function getConfig(pluginConfig) {
+  return { ...DEFAULT_CONFIG, ...(pluginConfig || {}) };
+}
+
+function shouldProcess(agentId, cfg) {
+  if (!agentId) return false;
+  if (!cfg.agentIds || cfg.agentIds.length === 0) return true;
+  return cfg.agentIds.includes(agentId);
+}
+
+function isDebounced(sessionKey, cfg) {
+  if (!sessionKey) return false;
+  const last = lastWriteMap.get(sessionKey);
+  if (!last) return false;
+  return Date.now() - last < cfg.debounceMs;
+}
+
+function markWritten(sessionKey) {
+  if (sessionKey) {
+    lastWriteMap.set(sessionKey, Date.now());
+  }
+}
+
+/**
+ * Extract the last user+assistant exchange from messages array.
+ * OpenClaw message format: [{role: 'user'|'assistant', content: string|array}, ...]
+ */
+function extractLastExchange(messages) {
+  if (!Array.isArray(messages) || messages.length === 0) return null;
+
+  let lastAssistant = null;
+  let lastUser = null;
+
+  // Walk backwards to find last assistant, then user before it
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const msg = messages[i];
+    if (!msg || !msg.role) continue;
+
+    if (!lastAssistant && msg.role === "assistant") {
+      lastAssistant = extractTextContent(msg.content);
+    } else if (lastAssistant && !lastUser && msg.role === "user") {
+      lastUser = extractTextContent(msg.content);
+      break;
+    }
+  }
+
+  if (!lastAssistant && !lastUser) return null;
+
+  const parts = [];
+  if (lastUser) parts.push(`User: ${lastUser}`);
+  if (lastAssistant) parts.push(`Assistant: ${lastAssistant}`);
+
+  return parts.join("\n\n");
+}
+
+function extractTextContent(content) {
+  if (!content) return "";
+  if (typeof content === "string") return content.slice(0, 2000);
+  if (Array.isArray(content)) {
+    return content
+      .filter((c) => c && c.type === "text" && c.text)
+      .map((c) => c.text)
+      .join(" ")
+      .slice(0, 2000);
+  }
+  return String(content).slice(0, 2000);
+}
+
+async function writeToMem0(cfg, agentId, text) {
+  const url = `${cfg.mem0Url}/memory/add`;
+  const body = JSON.stringify({
+    text,
+    user_id: cfg.userId,
+    agent_id: agentId,
+    infer: true,
+  });
+
+  const resp = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body,
+    signal: AbortSignal.timeout(5000),
+  });
+
+  if (!resp.ok) {
+    const errText = await resp.text().catch(() => "unknown");
+    throw new Error(`mem0 add failed: ${resp.status} ${errText}`);
+  }
+
+  return await resp.json();
+}
+
+async function searchMem0(cfg, agentId, query) {
+  const params = new URLSearchParams({
+    query,
+    user_id: cfg.userId,
+    agent_id: agentId,
+    limit: String(cfg.injectLimit),
+  });
+
+  const url = `${cfg.mem0Url}/memory/search?${params}`;
+  const resp = await fetch(url, {
+    signal: AbortSignal.timeout(cfg.injectTimeoutMs),
+  });
+
+  if (!resp.ok) {
+    throw new Error(`mem0 search failed: ${resp.status}`);
+  }
+
+  const data = await resp.json();
+  return data.results || [];
+}
+
+function formatMemoriesForInjection(results, maxChars) {
+  if (!results || results.length === 0) return null;
+
+  const lines = results
+    .filter((r) => r && r.memory)
+    .map((r) => `- ${r.memory}`);
+
+  if (lines.length === 0) return null;
+
+  const text = lines.join("\n");
+  const truncated = text.slice(0, maxChars);
+
+  return `## Relevant Memories\n${truncated}`;
+}
+
+// ──────────────────────────────────────────────
+// Plugin Definition
+// ──────────────────────────────────────────────
+
+const plugin = {
+  id: "mem0-memory-plugin",
+  name: "Mem0 Memory Plugin",
+  description:
+    "Integrates mem0 memory service with OpenClaw via agent lifecycle hooks for real-time memory write and injection.",
+
+  register(api) {
+    const cfg = getConfig(api.pluginConfig);
+    console.log(
+      `[mem0-plugin] Registered. mem0Url=${cfg.mem0Url} userId=${cfg.userId} agentIds=${cfg.agentIds.join(",")}`
+    );
+    console.log(
+      `[mem0-plugin] enableWrite=${cfg.enableWrite} enableInject=${cfg.enableInject}`
+    );
+
+    // ── 1. agent_end: write conversation turn to mem0 ──
+    if (cfg.enableWrite) {
+      api.on("agent_end", async (event, ctx) => {
+        try {
+          if (!event.success) return;
+          const agentId = ctx.agentId;
+          if (!shouldProcess(agentId, cfg)) return;
+          if (isDebounced(ctx.sessionKey, cfg)) {
+            console.log(
+              `[mem0-plugin] agent_end debounced for session=${ctx.sessionKey}`
+            );
+            return;
+          }
+
+          const exchange = extractLastExchange(event.messages);
+          if (!exchange) return;
+
+          await writeToMem0(cfg, agentId, exchange);
+          markWritten(ctx.sessionKey);
+          console.log(
+            `[mem0-plugin] agent_end: wrote to mem0 agent=${agentId} session=${ctx.sessionKey}`
+          );
+        } catch (err) {
+          console.error(`[mem0-plugin] agent_end error:`, err.message);
+        }
+      });
+
+      // ── 3. before_compaction: flush to mem0 before compaction ──
+      api.on("before_compaction", async (event, ctx) => {
+        try {
+          const agentId = ctx.agentId;
+          if (!shouldProcess(agentId, cfg)) return;
+
+          const messages = event.messages;
+          if (!Array.isArray(messages) || messages.length === 0) return;
+
+          const exchange = extractLastExchange(messages);
+          if (!exchange) return;
+
+          await writeToMem0(cfg, agentId, exchange);
+          markWritten(ctx.sessionKey);
+          console.log(
+            `[mem0-plugin] before_compaction: flushed to mem0 agent=${agentId}`
+          );
+        } catch (err) {
+          console.error(`[mem0-plugin] before_compaction error:`, err.message);
+        }
+      });
+    }
+
+    // ── 2. before_prompt_build: inject memories into system prompt ──
+    if (cfg.enableInject) {
+      api.on("before_prompt_build", async (event, ctx) => {
+        try {
+          const agentId = ctx.agentId;
+          if (!shouldProcess(agentId, cfg)) return;
+
+          const query = (event.prompt || "").slice(0, 200);
+          if (!query.trim()) return;
+
+          const results = await searchMem0(cfg, agentId, query);
+          const injected = formatMemoriesForInjection(results, cfg.injectMaxChars);
+
+          if (!injected) return;
+
+          console.log(
+            `[mem0-plugin] before_prompt_build: injecting ${results.length} memories agent=${agentId}`
+          );
+
+          return { prependContext: injected };
+        } catch (err) {
+          // Timeout or search failure — silently skip injection
+          if (err.name === "TimeoutError" || err.name === "AbortError") {
+            console.log(`[mem0-plugin] before_prompt_build: search timed out, skipping injection`);
+          } else {
+            console.error(`[mem0-plugin] before_prompt_build error:`, err.message);
+          }
+          return;
+        }
+      });
+    }
+  },
+};
+
+export { plugin as default };

--- a/openclaw-plugin/index.js
+++ b/openclaw-plugin/index.js
@@ -11,9 +11,10 @@ const DEFAULT_CONFIG = {
   mem0Url: "http://localhost:8230",
   userId: "boss",
   agentIds: ["dev", "main", "pm", "researcher", "pjm", "prototype"],
-  enableWrite: true,
-  enableRawWrite: false,
-  enableInject: true,
+  enableWrite: false,
+  enableRawWrite: true,
+  enableInject: false,
+  enableCompactionFlush: true,
   minExchangeLength: 100,
   injectLimit: 5,
   injectMaxChars: 800,
@@ -201,8 +202,10 @@ const plugin = {
           console.error(`[mem0-plugin] agent_end error:`, err.message);
         }
       });
+    }
 
-      // ── 3. before_compaction: flush to mem0 before compaction ──
+    // ── 3. before_compaction: flush to mem0 before compaction ──
+    if (cfg.enableCompactionFlush) {
       api.on("before_compaction", async (event, ctx) => {
         try {
           const agentId = ctx.agentId;

--- a/openclaw-plugin/index.js
+++ b/openclaw-plugin/index.js
@@ -20,6 +20,7 @@ const DEFAULT_CONFIG = {
   injectMaxChars: 800,
   debounceMs: 60000, // 1 minute debounce per sessionKey
   injectTimeoutMs: 3000,
+  compactionMaxChars: 8000, // max chars to flush before compaction
 };
 
 // Debounce map: sessionKey -> last write timestamp
@@ -78,6 +79,30 @@ function extractLastExchange(messages) {
   if (lastAssistant) parts.push(`Assistant: ${lastAssistant}`);
 
   return parts.join("\n\n");
+}
+
+/**
+ * Extract all messages as a single text block for compaction flush.
+ * Format: "User: ...\n\nAssistant: ...\n\nUser: ...\n\n..."
+ * Truncated to maxChars total.
+ */
+function extractAllMessages(messages, maxChars = 8000) {
+  if (!Array.isArray(messages) || messages.length === 0) return null;
+
+  const parts = [];
+  for (const msg of messages) {
+    if (!msg || !msg.role) continue;
+    if (msg.role !== "user" && msg.role !== "assistant") continue;
+    const text = extractTextContent(msg.content);
+    if (!text.trim()) continue;
+    const role = msg.role === "user" ? "User" : "Assistant";
+    parts.push(`${role}: ${text}`);
+  }
+
+  if (parts.length === 0) return null;
+
+  const full = parts.join("\n\n");
+  return full.slice(0, maxChars);
 }
 
 function extractTextContent(content) {
@@ -214,13 +239,13 @@ const plugin = {
           const messages = event.messages;
           if (!Array.isArray(messages) || messages.length === 0) return;
 
-          const exchange = extractLastExchange(messages);
-          if (!exchange) return;
+          const fullContext = extractAllMessages(messages, cfg.compactionMaxChars);
+          if (!fullContext) return;
 
-          await writeToMem0(cfg, agentId, exchange, true);
+          await writeToMem0(cfg, agentId, fullContext, true);
           markWritten(ctx.sessionKey);
           console.log(
-            `[mem0-plugin] before_compaction: flushed to mem0 agent=${agentId}`
+            `[mem0-plugin] before_compaction: flushed ${fullContext.length} chars agent=${agentId}`
           );
         } catch (err) {
           console.error(`[mem0-plugin] before_compaction error:`, err.message);

--- a/openclaw-plugin/openclaw.plugin.json
+++ b/openclaw-plugin/openclaw.plugin.json
@@ -5,7 +5,7 @@
   "enabledByDefault": false,
   "configSchema": {
     "type": "object",
-    "additionalProperties": true,
+    "additionalProperties": false,
     "properties": {
       "mem0Url": {
         "type": "string",
@@ -21,11 +21,23 @@
       },
       "enableWrite": {
         "type": "boolean",
+        "default": false
+      },
+      "enableRawWrite": {
+        "type": "boolean",
         "default": true
       },
       "enableInject": {
         "type": "boolean",
+        "default": false
+      },
+      "enableCompactionFlush": {
+        "type": "boolean",
         "default": true
+      },
+      "minExchangeLength": {
+        "type": "number",
+        "default": 100
       },
       "injectLimit": {
         "type": "number",
@@ -38,6 +50,10 @@
       "debounceMs": {
         "type": "number",
         "default": 60000
+      },
+      "injectTimeoutMs": {
+        "type": "number",
+        "default": 3000
       }
     }
   }

--- a/openclaw-plugin/openclaw.plugin.json
+++ b/openclaw-plugin/openclaw.plugin.json
@@ -1,0 +1,44 @@
+{
+  "id": "mem0-memory-plugin",
+  "name": "Mem0 Memory Plugin",
+  "description": "Integrates mem0 memory service with OpenClaw via agent lifecycle hooks for real-time memory write and injection.",
+  "enabledByDefault": false,
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": true,
+    "properties": {
+      "mem0Url": {
+        "type": "string",
+        "default": "http://localhost:8230"
+      },
+      "userId": {
+        "type": "string",
+        "default": "boss"
+      },
+      "agentIds": {
+        "type": "array",
+        "items": { "type": "string" }
+      },
+      "enableWrite": {
+        "type": "boolean",
+        "default": true
+      },
+      "enableInject": {
+        "type": "boolean",
+        "default": true
+      },
+      "injectLimit": {
+        "type": "number",
+        "default": 5
+      },
+      "injectMaxChars": {
+        "type": "number",
+        "default": 800
+      },
+      "debounceMs": {
+        "type": "number",
+        "default": 60000
+      }
+    }
+  }
+}

--- a/openclaw-plugin/package.json
+++ b/openclaw-plugin/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "openclaw-mem0-plugin",
+  "version": "0.1.0",
+  "description": "OpenClaw plugin for mem0 memory service integration via agent lifecycle hooks",
+  "type": "module",
+  "main": "index.js",
+  "keywords": ["openclaw", "mem0", "memory", "plugin"],
+  "license": "MIT"
+}


### PR DESCRIPTION
## 概述

新增 `openclaw-plugin/` 目录，将 mem0 记忆服务通过 OpenClaw Plugin hook 系统与 agent 生命周期集成，实现**实时（turn 级别）**记忆写入和注入，替代原来 auto_digest 的 15 分钟延迟批处理。

## 实现的 Hooks

| Hook | 功能 |
|------|------|
| `agent_end` | 每次 turn 成功结束后写入 mem0（infer=true，60s debounce） |
| `before_prompt_build` | 用当前 prompt 搜索相关记忆，注入到系统提示（3s 超时保护） |
| `before_compaction` | session 压缩前兜底写入 mem0 |

## 配置

在 `~/.openclaw/openclaw.json` 的 `plugins.entries.openclaw-plugin` 中配置，支持：
- mem0Url / userId / agentIds 过滤
- enableWrite / enableInject 开关
- injectLimit / injectMaxChars 限制
- debounceMs 去重窗口

## 文件结构

```
openclaw-plugin/
├── index.js              # 插件主文件（纯 ES Module）
├── package.json          # type=module
└── openclaw.plugin.json  # OpenClaw plugin manifest
```