### PR TITLE
feat: agent_end hook 直接写日记文件替代 session_snapshot

### DIFF
--- a/openclaw-plugin/index.js
+++ b/openclaw-plugin/index.js
@@ -150,7 +150,7 @@ function isNoise(text) {
 
 function cleanContent(text) {
   if (!text || !text.trim()) return '';
-  text = text.replace(/\[message_id=om_[a-f0-9]+\]\s*/g, '');
+  text = text.replace(/\[message_id=om_[a-zA-Z0-9]+\]\s*/g, '');
   text = text.replace(
     /(?:Conversation info|Sender|Inbound Context|Replied message)\s*\(.*?\):\s*```json[\s\S]*?```/g,
     ''

--- a/openclaw-plugin/index.js
+++ b/openclaw-plugin/index.js
@@ -9,7 +9,7 @@
  */
 
 import { appendFileSync, existsSync, mkdirSync, writeFileSync } from "fs";
-import { join, dirname } from "path";
+import { join } from "path";
 
 const DEFAULT_CONFIG = {
   mem0Url: "http://localhost:8230",
@@ -126,6 +126,17 @@ function extractTextContent(content) {
 }
 
 /**
+ * Get workspace base path for a given agentId.
+ * Each agent writes to its own workspace: ~/.openclaw/workspace-{agentId}
+ */
+function getWorkspaceBase(cfg, agentId) {
+  const base = cfg.diaryBasePath; // e.g. ~/.openclaw/workspace-dev
+  const openclawBase = join(base, ".."); // ~/.openclaw/
+  if (!agentId) return base;
+  return join(openclawBase, `workspace-${agentId}`);
+}
+
+/**
  * Append a conversation exchange to today's diary file.
  * Format matches session_snapshot.py output for consistency.
  */
@@ -134,7 +145,8 @@ function writeDiaryEntry(cfg, agentId, sessionKey, messages) {
   const today = now.toISOString().slice(0, 10);
   const hhmm = now.toISOString().slice(11, 16);
 
-  const diaryDir = join(cfg.diaryBasePath, "memory");
+  const workspaceBase = getWorkspaceBase(cfg, agentId);
+  const diaryDir = join(workspaceBase, "memory");
   const diaryPath = join(diaryDir, `${today}.md`);
 
   // Extract last user + assistant messages
@@ -167,8 +179,8 @@ function writeDiaryEntry(cfg, agentId, sessionKey, messages) {
 
   // Build entry
   const lines = [`### [${hhmm}] Session ${agentId}:${shortSession}`];
-  if (lastAssistant) lines.push(`- ${agentId}: ${lastAssistant}`);
   if (lastUser) lines.push(`- Boss: ${lastUser}`);
+  if (lastAssistant) lines.push(`- ${agentId}: ${lastAssistant}`);
   lines.push(""); // trailing blank line
 
   appendFileSync(diaryPath, lines.join("\n") + "\n");
@@ -261,24 +273,19 @@ const plugin = {
           if (!event.success) return;
           const agentId = ctx.agentId;
           if (!shouldProcess(agentId, cfg)) return;
-          if (isDebounced(ctx.sessionKey, cfg)) return;
-
-          const exchange = extractLastExchange(event.messages);
-          if (!exchange) return;
-
-          // 过滤太短的内容（纯寒暄/确认）
-          if (exchange.length < cfg.minExchangeLength) return;
 
           if (cfg.enableWrite) {
-            // infer=true，让 mem0 自动提炼
+            // infer=true，让 mem0 自动提炼，保留 debounce
+            if (isDebounced(ctx.sessionKey, cfg)) return;
+            const exchange = extractLastExchange(event.messages);
+            if (!exchange || exchange.length < cfg.minExchangeLength) return;
             await writeToMem0(cfg, agentId, exchange, true);
             markWritten(ctx.sessionKey);
             console.log(`[mem0-plugin] agent_end: infer write agent=${agentId}`);
           } else if (cfg.enableRawWrite) {
-            // 直接写日记文件，替代 session_snapshot 轮询
+            // 写日记文件，不 debounce，每轮都写
             const ok = writeDiaryEntry(cfg, agentId, ctx.sessionKey, event.messages);
             if (ok) {
-              markWritten(ctx.sessionKey);
               console.log(`[mem0-plugin] agent_end: diary write agent=${agentId}`);
             }
           }

--- a/openclaw-plugin/index.js
+++ b/openclaw-plugin/index.js
@@ -136,6 +136,44 @@ function getWorkspaceBase(cfg, agentId) {
   return join(openclawBase, `workspace-${agentId}`);
 }
 
+function isNoise(text) {
+  if (!text || text.trim().length < 15) return true;
+  const lower = text.toLowerCase();
+  if (lower.includes('heartbeat') && !text.includes('HEARTBEAT.md')) return true;
+  if (text.startsWith('$ ') || text.startsWith('> ')) return true;
+  if (text.trim() === 'NO_REPLY') return true;
+  const fillerRe = /^(好的|收到|明白了?|了解|OK|Done|Sure|Got it|Yes|No|嗯|对|是的)[.。]?$/i;
+  if (fillerRe.test(text.trim())) return true;
+  return false;
+}
+
+function cleanContent(text) {
+  if (!text || !text.trim()) return '';
+  text = text.replace(/\[message_id=om_[a-f0-9]+\]\s*/g, '');
+  text = text.replace(
+    /(?:Conversation info|Sender|Inbound Context|Replied message)\s*\(.*?\):\s*```json[\s\S]*?```/g,
+    ''
+  );
+  text = text.replace(/^Runtime:\s*agent=.*$/mg, '');
+  text = text.replace(/^## \/home\/.*?\.md\b[\s\S]*?(?=^## |\z)/mg, '');
+  text = text.replace(
+    /^##\s+(?:Group Chat Context|Inbound Context \(trusted metadata\)|Dynamic Project Context|Silent Replies|Authorized Senders)[\s\S]*?(?=^## |\z)/mg,
+    ''
+  );
+  text = text.replace(
+    /```(?:json)?\s*\n(?:\s*[{\["'].*\n){3,}[\s\S]*?```/g,
+    '[...output omitted...]'
+  );
+  text = text.replace(
+    /```(?:bash|sh|shell|console|text)?\s*\n(?:.*\n){5,}?```/g,
+    '[...output omitted...]'
+  );
+  text = text.replace(/\n{3,}/g, '\n\n');
+  text = text.replace(/[ \t]+/g, ' ');
+  text = text.trim();
+  return text;
+}
+
 /**
  * Append a conversation exchange to today's diary file.
  * Format matches session_snapshot.py output for consistency.
@@ -156,12 +194,25 @@ function writeDiaryEntry(cfg, agentId, sessionKey, messages) {
     const msg = messages[i];
     if (!msg || !msg.role) continue;
     if (!lastAssistant && msg.role === "assistant") {
-      lastAssistant = extractTextContent(msg.content).slice(0, 500);
+      lastAssistant = extractTextContent(msg.content);
     } else if (lastAssistant && !lastUser && msg.role === "user") {
-      lastUser = extractTextContent(msg.content).slice(0, 500);
+      lastUser = extractTextContent(msg.content);
       break;
     }
   }
+
+  // Clean content and filter noise before truncation
+  if (lastAssistant) {
+    lastAssistant = cleanContent(lastAssistant);
+    if (isNoise(lastAssistant)) lastAssistant = null;
+    else lastAssistant = lastAssistant.slice(0, 500);
+  }
+  if (lastUser) {
+    lastUser = cleanContent(lastUser);
+    if (isNoise(lastUser)) lastUser = null;
+    else lastUser = lastUser.slice(0, 500);
+  }
+
   if (!lastAssistant && !lastUser) return false;
 
   // Short session name: last segment of colon-separated key, max 20 chars

--- a/openclaw-plugin/index.js
+++ b/openclaw-plugin/index.js
@@ -127,12 +127,13 @@ function extractTextContent(content) {
 
 /**
  * Get workspace base path for a given agentId.
- * Each agent writes to its own workspace: ~/.openclaw/workspace-{agentId}
+ * OPENCLAW_BASE points to ~/.openclaw, workspaces are under it.
  */
-function getWorkspaceBase(cfg, agentId) {
-  const base = cfg.diaryBasePath; // e.g. ~/.openclaw/workspace-dev
-  const openclawBase = join(base, ".."); // ~/.openclaw/
-  if (!agentId) return base;
+function getWorkspaceBase(agentId) {
+  const openclawBase =
+    process.env.OPENCLAW_BASE ||
+    join(process.env.HOME || "/root", ".openclaw");
+  if (!agentId) return join(openclawBase, "workspace-dev");
   return join(openclawBase, `workspace-${agentId}`);
 }
 
@@ -183,7 +184,7 @@ function writeDiaryEntry(cfg, agentId, sessionKey, messages) {
   const today = now.toISOString().slice(0, 10);
   const hhmm = now.toISOString().slice(11, 16);
 
-  const workspaceBase = getWorkspaceBase(cfg, agentId);
+  const workspaceBase = getWorkspaceBase(agentId);
   const diaryDir = join(workspaceBase, "memory");
   const diaryPath = join(diaryDir, `${today}.md`);
 

--- a/openclaw-plugin/index.js
+++ b/openclaw-plugin/index.js
@@ -2,17 +2,21 @@
  * OpenClaw mem0 Memory Plugin
  *
  * Hooks into OpenClaw's agent lifecycle to:
- * - Write conversation turns to mem0 (agent_end hook)
+ * - Write conversation turns to diary file (agent_end hook, enableRawWrite)
+ * - Write conversation turns to mem0 with infer (agent_end hook, enableWrite)
  * - Inject relevant memories into system prompt (before_prompt_build hook)
  * - Flush conversation to mem0 before compaction (before_compaction hook)
  */
+
+import { appendFileSync, existsSync, mkdirSync, writeFileSync } from "fs";
+import { join, dirname } from "path";
 
 const DEFAULT_CONFIG = {
   mem0Url: "http://localhost:8230",
   userId: "boss",
   agentIds: ["dev", "main", "pm", "researcher", "pjm", "prototype"],
   enableWrite: false,
-  enableRawWrite: true,
+  enableRawWrite: true, // write diary file (replaces raw mem0 write)
   enableInject: false,
   enableCompactionFlush: true,
   minExchangeLength: 100,
@@ -21,6 +25,9 @@ const DEFAULT_CONFIG = {
   debounceMs: 60000, // 1 minute debounce per sessionKey
   injectTimeoutMs: 3000,
   compactionMaxChars: 8000, // max chars to flush before compaction
+  diaryBasePath:
+    process.env.OPENCLAW_BASE ||
+    join(process.env.HOME || "/root", ".openclaw", "workspace-dev"),
 };
 
 // Debounce map: sessionKey -> last write timestamp
@@ -116,6 +123,56 @@ function extractTextContent(content) {
       .slice(0, 2000);
   }
   return String(content).slice(0, 2000);
+}
+
+/**
+ * Append a conversation exchange to today's diary file.
+ * Format matches session_snapshot.py output for consistency.
+ */
+function writeDiaryEntry(cfg, agentId, sessionKey, messages) {
+  const now = new Date();
+  const today = now.toISOString().slice(0, 10);
+  const hhmm = now.toISOString().slice(11, 16);
+
+  const diaryDir = join(cfg.diaryBasePath, "memory");
+  const diaryPath = join(diaryDir, `${today}.md`);
+
+  // Extract last user + assistant messages
+  let lastAssistant = null;
+  let lastUser = null;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const msg = messages[i];
+    if (!msg || !msg.role) continue;
+    if (!lastAssistant && msg.role === "assistant") {
+      lastAssistant = extractTextContent(msg.content).slice(0, 500);
+    } else if (lastAssistant && !lastUser && msg.role === "user") {
+      lastUser = extractTextContent(msg.content).slice(0, 500);
+      break;
+    }
+  }
+  if (!lastAssistant && !lastUser) return false;
+
+  // Short session name: last segment of colon-separated key, max 20 chars
+  const shortSession = (sessionKey || "unknown").split(":").pop().slice(0, 20);
+
+  // Ensure directory exists
+  if (!existsSync(diaryDir)) {
+    mkdirSync(diaryDir, { recursive: true });
+  }
+
+  // Create file header if new
+  if (!existsSync(diaryPath)) {
+    writeFileSync(diaryPath, `# ${today} - Dev Agent 日记\n\n## Session 记录\n\n`);
+  }
+
+  // Build entry
+  const lines = [`### [${hhmm}] Session ${agentId}:${shortSession}`];
+  if (lastAssistant) lines.push(`- ${agentId}: ${lastAssistant}`);
+  if (lastUser) lines.push(`- Boss: ${lastUser}`);
+  lines.push(""); // trailing blank line
+
+  appendFileSync(diaryPath, lines.join("\n") + "\n");
+  return true;
 }
 
 async function writeToMem0(cfg, agentId, text, infer = true, timeoutMs = 5000) {
@@ -218,10 +275,12 @@ const plugin = {
             markWritten(ctx.sessionKey);
             console.log(`[mem0-plugin] agent_end: infer write agent=${agentId}`);
           } else if (cfg.enableRawWrite) {
-            // infer=false，原文存入
-            await writeToMem0(cfg, agentId, exchange, false);
-            markWritten(ctx.sessionKey);
-            console.log(`[mem0-plugin] agent_end: raw write agent=${agentId}`);
+            // 直接写日记文件，替代 session_snapshot 轮询
+            const ok = writeDiaryEntry(cfg, agentId, ctx.sessionKey, event.messages);
+            if (ok) {
+              markWritten(ctx.sessionKey);
+              console.log(`[mem0-plugin] agent_end: diary write agent=${agentId}`);
+            }
           }
         } catch (err) {
           console.error(`[mem0-plugin] agent_end error:`, err.message);

--- a/openclaw-plugin/package.json
+++ b/openclaw-plugin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openclaw-mem0-plugin",
   "version": "0.1.0",
-  "description": "OpenClaw plugin for mem0 memory service integration via agent lifecycle hooks",
+  "description": "OpenClaw plugin for diary file writing and mem0 memory service integration via agent lifecycle hooks",
   "type": "module",
   "main": "index.js",
   "keywords": ["openclaw", "mem0", "memory", "plugin"],


### PR DESCRIPTION
## 改动说明

`agent_end` hook 的 `enableRawWrite` 分支从调用 `writeToMem0(infer=false)` 改为直接 append 写本地日记文件，替代 `session_snapshot.py` 的 5 分钟轮询写入。

### 变更内容

- **新增 `writeDiaryEntry` 函数**：按日期创建 `memory/YYYY-MM-DD.md`，同步追加会话记录
- **新增 `diaryBasePath` 配置项**：默认 `~/.openclaw/workspace-dev`，支持 `OPENCLAW_BASE` 环境变量覆盖
- **添加 `fs`/`path` ESM import**
- **保持不变**：`before_compaction`（flush to mem0）、`before_prompt_build`（inject）、`enableWrite` 分支（infer=true）

### 日记文件格式

```markdown
### [HH:MM] Session agentId:sessionShortName
- agentId: assistant 消息（截断 500 字）
- Boss: user 消息（截断 500 字）
```

### 优势

- 实时写入（每次 agent_end 触发），不再依赖 5 分钟轮询
- 零网络开销（本地文件 I/O），不触发 embedding 和向量库写入
- 与现有 `auto_digest.py` pipeline 无缝衔接

Closes #152